### PR TITLE
Don’t try to extract anything when there are no PHP files

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -28,9 +28,18 @@ Feature: Generate a POT file of a WordPress plugin
 
   Scenario: Does include file headers.
     When I run `wp scaffold plugin hello-world --plugin_name="Hello World" --plugin_author="John Doe" --plugin_author_uri="https://example.com" --plugin_uri="https://foo.example.com"`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
 
     When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot`
     Then the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
       """
       msgid "Hello World"

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -26,6 +26,28 @@ Feature: Generate a POT file of a WordPress plugin
     And STDERR should be empty
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
 
+  Scenario: Does include file headers.
+    When I run `wp scaffold plugin hello-world --plugin_name="Hello World" --plugin_author="John Doe" --plugin_author_uri="https://example.com" --plugin_uri="https://foo.example.com"`
+
+    When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot`
+    Then the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "John Doe"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "https://example.com"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "https://foo.example.com"
+      """
+
   Scenario: Does not include empty file headers.
     When I run `wp scaffold plugin hello-world --plugin_description=""`
 
@@ -461,4 +483,34 @@ Feature: Generate a POT file of a WordPress plugin
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       #. translators: this should get extracted too.
+      """
+
+  Scenario: Generates a POT file for a child theme with no other files
+    When I run `wp scaffold child-theme foobar --parent_theme=twentyseventeen --theme_name="Foo Bar" --author="Jane Doe" --author_uri="https://example.com" --theme_uri="https://foobar.example.com"`
+    Then the wp-content/themes/foobar directory should exist
+    And the wp-content/themes/foobar/style.css file should exist
+
+    When I run `wp i18n make-pot wp-content/themes/foobar wp-content/themes/foobar/languages/foobar.pot`
+    Then STDOUT should be:
+      """
+      Theme stylesheet detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the wp-content/themes/foobar/languages/foobar.pot file should exist
+    And the wp-content/themes/foobar/languages/foobar.pot file should contain:
+      """
+      msgid "Foo Bar"
+      """
+    And the wp-content/themes/foobar/languages/foobar.pot file should contain:
+      """
+      msgid "Jane Doe"
+      """
+    And the wp-content/themes/foobar/languages/foobar.pot file should contain:
+      """
+      msgid "https://example.com"
+      """
+    And the wp-content/themes/foobar/languages/foobar.pot file should contain:
+      """
+      msgid "https://foobar.example.com"
       """

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -151,11 +151,29 @@ class MakePotCommand extends WP_CLI_Command {
 	 * @return array List of file headers.
 	 */
 	protected function get_file_headers( $type ) {
-		switch( $type ) {
+		switch ( $type ) {
 			case 'plugin':
-				return [ 'Plugin Name', 'Plugin URI', 'Description', 'Author', 'Author URI', 'Version', 'Domain Path' ];
+				return [
+					'Plugin Name',
+					'Plugin URI',
+					'Description',
+					'Author',
+					'Author URI',
+					'Version',
+					'Domain Path'
+				];
 			case 'theme':
-				return [ 'Theme Name', 'Theme URI', 'Description', 'Author', 'Author URI', 'Version', 'License', 'Domain Path' ];
+				return [
+					'Theme Name',
+					'Theme URI',
+					'Description',
+					'Author',
+					'Author URI',
+					'Version',
+					'License',
+					'Domain Path',
+					'Text Domain'
+				];
 			default:
 				return [];
 		}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -160,7 +160,7 @@ class MakePotCommand extends WP_CLI_Command {
 					'Author',
 					'Author URI',
 					'Version',
-					'Domain Path'
+					'Domain Path',
 				];
 			case 'theme':
 				return [
@@ -172,7 +172,6 @@ class MakePotCommand extends WP_CLI_Command {
 					'Version',
 					'License',
 					'Domain Path',
-					'Text Domain'
 				];
 			default:
 				return [];

--- a/src/WordPressCodeExtractor.php
+++ b/src/WordPressCodeExtractor.php
@@ -91,7 +91,17 @@ class WordPressCodeExtractor extends PhpCode {
 	 */
 	public static function fromDirectory( $dir, Translations $translations, array $options = [] ) {
 		static::$dir = $dir;
-		static::fromFile( static::getFilesFromDirectory( $dir ), $translations, $options );
+
+		$files = static::getFilesFromDirectory( $dir );
+
+		try {
+			if ( ! empty( $files ) ) {
+				static::fromFile( $files, $translations, $options );
+			}
+		} catch ( \Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
+
 		static::$dir = '';
 	}
 


### PR DESCRIPTION
This is commonly the case when adding a child theme where only strings from `style.css` should get extracted but nothing else.

Without this change, `\Gettext\Extractors\Extractor::getFiles()` throws an `InvalidArgumentException` when being passed an empty array.

Now, the function is not being called in that scenario. Plus, any exceptions will be caught an printed by `WP_CLI::error()`.
