### PR TITLE
Add ability to merge with existing POT file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ wp i18n
 Create a POT file for a WordPress plugin or theme.
 
 ~~~
-wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--merge=<file>]
+wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--merge[=<file>]]
 ~~~
 
 **OPTIONS**
@@ -48,11 +48,9 @@ wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [-
 	[--domain=<domain>]
 		Text domain to look for in the source code. Defaults to the plugin/theme slug.
 
-	[--merge=<file>]
+	[--merge[=<file>]]
 		Existing POT file file whose content should be merged with the extracted strings.
-		---
-		default: destination POT file
-		---
+		If left empty, defaults to the destination POT file.
 
 **EXAMPLES**
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [-
 
 	[--merge[=<file>]]
 		Existing POT file file whose content should be merged with the extracted strings.
-		By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
-		Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
+		If left empty, defaults to the destination POT file.
 
 	[--exclude=<paths>]
 		Include additional ignored paths as CSV (e.g. 'tests,bin,.github').
-		If left empty, defaults to the destination POT file.
+		By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
+		Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
 
 **EXAMPLES**
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@ This package implements the following commands:
 
 ### wp i18n
 
-
+Provides internationalization tools for WordPress projects.
 
 ~~~
 wp i18n
 ~~~
 
+**EXAMPLES**
 
+    # Create a POT file for the WordPress plugin/theme in the current directory
+    $ wp i18n make-pot . languages/my-plugin.pot
 
 
 
@@ -28,7 +31,7 @@ wp i18n
 Create a POT file for a WordPress plugin or theme.
 
 ~~~
-wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>]
+wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--merge=<file>]
 ~~~
 
 **OPTIONS**
@@ -44,6 +47,12 @@ wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>]
 
 	[--domain=<domain>]
 		Text domain to look for in the source code. Defaults to the plugin/theme slug.
+
+	[--merge=<file>]
+		Existing POT file file whose content should be merged with the extracted strings.
+		---
+		default: destination POT file
+		---
 
 **EXAMPLES**
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ wp i18n
 Create a POT file for a WordPress plugin or theme.
 
 ~~~
-wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--exclude=<paths>]
+wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--merge[=<file>]] [--exclude=<paths>]
 ~~~
 
 **OPTIONS**
@@ -43,17 +43,19 @@ wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [-
 		Name of the resulting POT file.
 
 	[--slug=<slug>]
-		Plugin slug. Defaults to the source directory's basename.
+		Plugin or theme slug. Defaults to the source directory's basename.
 
 	[--domain=<domain>]
 		Text domain to look for in the source code. Defaults to the plugin/theme slug.
 
+	[--merge[=<file>]]
+		Existing POT file file whose content should be merged with the extracted strings.
+		By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
+		Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
+
 	[--exclude=<paths>]
 		Include additional ignored paths as CSV (e.g. 'tests,bin,.github').
-
-By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
-
-Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
+		If left empty, defaults to the destination POT file.
 
 **EXAMPLES**
 

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -621,3 +621,76 @@ Feature: Generate a POT file of a WordPress plugin
       """
       msgid "Hello World JS"
       """
+
+  Scenario: Uses newer file headers when merging translations
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: John Doe <johndoe@example.com>\n"
+      "Language-Team: Language Team <foo@example.com>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr ""
+      """
+
+    When I run `wp scaffold plugin hello-world --plugin_name="Hello World" --plugin_author="John Doe" --plugin_author_uri="https://example.com" --plugin_uri="https://foo.example.com"`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+
+    When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot --merge=foo-plugin/foo-plugin.pot`
+    Then the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      # Copyright (C) 2018 Hello World
+      # This file is distributed under the same license as the Hello World package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Hello World 0.1.0\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/hello-world\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should not contain:
+      """
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      "X-Domain: hello-world\n"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      #: foo-plugin.js:15
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Foo Plugin"
+      """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -523,3 +523,101 @@ Feature: Generate a POT file of a WordPress plugin
       """
       msgid "https://foobar.example.com"
       """
+
+  Scenario: Merges translations with the ones from an existing POT file
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr ""
+      """
+
+    When I run `wp scaffold plugin hello-world --plugin_name="Hello World" --plugin_author="John Doe" --plugin_author_uri="https://example.com" --plugin_uri="https://foo.example.com"`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+
+    When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot --merge=foo-plugin/foo-plugin.pot`
+    Then the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      #: foo-plugin.js:15
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Foo Plugin"
+      """
+
+  Scenario: Merges translations with existing destination file
+    When I run `wp scaffold plugin hello-world --plugin_name="Hello World" --plugin_author="John Doe" --plugin_author_uri="https://example.com" --plugin_uri="https://foo.example.com"`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+
+    Given a wp-content/plugins/hello-world/languages/hello-world.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #: hello-world.js:15
+      msgid "Hello World JS"
+      msgstr ""
+      """
+
+    When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot --merge`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      #: hello-world.js:15
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Hello World JS"
+      """

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -122,6 +122,8 @@ class MakePotCommand extends WP_CLI_Command {
 
 				$this->merge = $assoc_args['merge'];
 			}
+		}
+
 		if ( isset( $assoc_args['exclude'] ) ) {
 			$this->exclude = array_filter( array_merge( $this->exclude, explode( ',', $assoc_args['exclude'] ) ) );
 			$this->exclude = array_map(function($exclude) {

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -67,12 +67,12 @@ class MakePotCommand extends WP_CLI_Command {
 	 *
 	 * [--merge[=<file>]]
 	 * : Existing POT file file whose content should be merged with the extracted strings.
-	 * By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
-	 * Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
+	 * If left empty, defaults to the destination POT file.
 	 *
 	 * [--exclude=<paths>]
 	 * : Include additional ignored paths as CSV (e.g. 'tests,bin,.github').
-	 * If left empty, defaults to the destination POT file.
+	 * By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
+	 * Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -59,7 +59,7 @@ class MakePotCommand extends WP_CLI_Command {
 	 * [--domain=<domain>]
 	 * : Text domain to look for in the source code. Defaults to the plugin/theme slug.
 	 *
-	 * [--merge=<file>]
+	 * [--merge[=<file>]]
 	 * : Existing POT file file whose content should be merged with the extracted strings.
 	 * If left empty, defaults to the destination POT file.
 	 *
@@ -101,11 +101,9 @@ class MakePotCommand extends WP_CLI_Command {
 		}
 
 		if ( isset( $assoc_args['merge'] ) ) {
-			if ( empty( $assoc_args['merge'] ) && file_exists( $this->destination ) ) {
+			if ( true === $assoc_args['merge'] && file_exists( $this->destination ) ) {
 				$this->merge = $this->destination;
-			}
-
-			if ( ! empty( $assoc_args['merge'] ) ) {
+			} elseif ( ! empty( $assoc_args['merge'] ) ) {
 				if ( ! file_exists( $assoc_args['merge'] ) ) {
 					WP_CLI::error( sprintf( 'Invalid file %s', $assoc_args['merge'] ) );
 				}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -34,7 +34,7 @@ class MakePotCommand extends WP_CLI_Command {
 	protected $merge;
 
 	/**
-	 * @var string
+	 * @var array
 	 */
 	protected $exclude = [ 'node_modules', '.git', '.svn', '.CVS', '.hg', 'vendor' ];
 

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -60,20 +60,19 @@ class MakePotCommand extends WP_CLI_Command {
 	 * : Name of the resulting POT file.
 	 *
 	 * [--slug=<slug>]
-	 * : Plugin slug. Defaults to the source directory's basename.
+	 * : Plugin or theme slug. Defaults to the source directory's basename.
 	 *
 	 * [--domain=<domain>]
 	 * : Text domain to look for in the source code. Defaults to the plugin/theme slug.
 	 *
 	 * [--merge[=<file>]]
 	 * : Existing POT file file whose content should be merged with the extracted strings.
-	 * If left empty, defaults to the destination POT file.
+	 * By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
+	 * Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
+	 *
 	 * [--exclude=<paths>]
 	 * : Include additional ignored paths as CSV (e.g. 'tests,bin,.github').
-	 *
-	 * By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
-	 *
-	 * Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
+	 * If left empty, defaults to the destination POT file.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -3,6 +3,7 @@
 namespace WP_CLI\I18n;
 
 use Gettext\Extractors\Po;
+use Gettext\Merge;
 use Gettext\Translation;
 use Gettext\Translations;
 use WP_CLI;
@@ -219,9 +220,11 @@ class MakePotCommand extends WP_CLI_Command {
 	protected function makepot( $domain ) {
 		$this->translations = new Translations();
 
-		// Add existing strings first.
+		// Add existing strings first but don't keep headers.
 		if ( $this->merge ) {
-			Po::fromFile( $this->merge, $this->translations );
+			$existing_translations = new Translations();
+			Po::fromFile( $this->merge, $existing_translations );
+			$this->translations->mergeWith( $existing_translations, Merge::ADD | Merge::REMOVE );
 		}
 
 		$meta = $this->get_meta_data();


### PR DESCRIPTION
Fixes #29.

Todo:

* [x] Make sure the headers of the resulting POT file aren't overridden by the existing one.
* [x] Figure out how to omit `--merge` and have it pick the destination file.