### PR TITLE
Add warning when a string has two different translator comments

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -536,6 +536,9 @@ Feature: Generate a POT file of a WordPress plugin
       /* translators: Translators 1! */
       __( 'Hello World', 'foo-plugin' );
 
+      /* translators: Translators 1! */
+      __( 'Hello World', 'foo-plugin' );
+
       /* Translators: Translators 2! */
       __( 'Hello World', 'foo-plugin' );
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -523,3 +523,30 @@ Feature: Generate a POT file of a WordPress plugin
       """
       msgid "https://foobar.example.com"
       """
+
+  Scenario: Prints a warning when two identical strings have different translator comments.
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Plugin name
+       */
+
+      /* translators: Translators 1! */
+      __( 'Hello World', 'foo-plugin' );
+
+      /* Translators: Translators 2! */
+      __( 'Hello World', 'foo-plugin' );
+      """
+
+    When I run `wp i18n make-pot foo-plugin --debug`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should contain:
+      """
+      Warning: The string "Hello World" has 2 different translator comments.
+      """

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -233,6 +233,23 @@ class MakePotCommand extends WP_CLI_Command {
 			$this->translations[] = $translation;
 		}
 
+		foreach( $this->translations as $translation ) {
+			if ( ! $translation->hasExtractedComments() ) {
+				continue;
+			}
+
+			$comments = array_unique( $translation->getExtractedComments() );
+			$comments_count = count( $comments );
+
+			if ( $comments_count > 1 ) {
+				WP_CLI::warning( sprintf(
+					'The string "%1$s" has %2$d different translator comments.',
+					$translation->getOriginal(),
+					$comments_count
+				) );
+			}
+		}
+
 		return PotGenerator::toFile( $this->translations, $this->destination );
 	}
 

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -238,7 +238,7 @@ class MakePotCommand extends WP_CLI_Command {
 				continue;
 			}
 
-			$comments = array_unique( $translation->getExtractedComments() );
+			$comments = $translation->getExtractedComments();
 			$comments_count = count( $comments );
 
 			if ( $comments_count > 1 ) {

--- a/src/WordPressFunctionsScanner.php
+++ b/src/WordPressFunctionsScanner.php
@@ -80,11 +80,11 @@ class WordPressFunctionsScanner extends PhpFunctionsScanner {
 			// Todo: Require a domain?
 			if ( (string) $original !== '' && ( $domain === null || $domain === $translations->getDomain() ) ) {
 				$translation = $translations->insert( $context, $original, $plural );
-				$translation->addReference( $file, $line );
+				$translation = $translation->addReference( $file, $line );
 
 				if ( isset( $function[3] ) ) {
 					foreach ( $function[3] as $extractedComment ) {
-						$translation->addExtractedComment( $extractedComment );
+						$translation = $translation->addExtractedComment( $extractedComment );
 					}
 				}
 			}


### PR DESCRIPTION
I want to test this with a few plugins and themes to see how useful this really is.

Fixes #33.