### PR TITLE
Correctly pass exclude option to JsCodeExtractor

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -620,6 +620,10 @@ Feature: Generate a POT file of a WordPress plugin
       <?php
        __( 'I am being ignored', 'foo-plugin' );
       """
+     And a foo-plugin/bar/ignored.js file:
+      """
+      __( 'I am being ignored', 'foo-plugin' );
+      """
 
     When I run `wp i18n make-pot foo-plugin foo-plugin.pot --exclude=foo,bar`
     Then the foo-plugin.pot file should not contain:

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -298,7 +298,13 @@ class MakePotCommand extends WP_CLI_Command {
 			] );
 
 			if ( ! $this->skip_js ) {
-				JsCodeExtractor::fromDirectory( $this->source, $this->translations );
+				JsCodeExtractor::fromDirectory(
+					$this->source,
+					$this->translations,
+					[
+						'exclude' => $this->exclude,
+					]
+				);
 			}
 		} catch ( \Exception $e ) {
 			WP_CLI::error( $e->getMessage() );


### PR DESCRIPTION
This fixes an oversight after working on #26 and #31 simultaneously.

When fixing the merge conflict for the JS extraction PR, I probably forgot to pass the `exclude` option to the JS scanner as well.

Just noticed this after I ran into a timeout trying to extract strings from hundreds of JS files inside `vendor` 🙃 

Added a test to make sure JS files are taken into account as well.