### PR TITLE
Add option to extract strings with any text domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ wp i18n
 Create a POT file for a WordPress plugin or theme.
 
 ~~~
-wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--merge[=<file>]] [--exclude=<paths>] [--skip-js]
+wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--ignore-domain] [--merge[=<file>]] [--exclude=<paths>] [--skip-js]
 ~~~
 
 Scans PHP and JavaScript files, as well as theme stylesheets for translatable strings.
@@ -48,7 +48,10 @@ Scans PHP and JavaScript files, as well as theme stylesheets for translatable st
 		Plugin or theme slug. Defaults to the source directory's basename.
 
 	[--domain=<domain>]
-		Text domain to look for in the source code. Defaults to the plugin/theme slug.
+		Text domain to look for in the source code. Defaults to the plugin/theme slug, unless the `--ignore-domain` option is used.
+
+	[--ignore-domain]
+		Ignore the text domain completely and extract strings with any text domain.
 
 	[--merge[=<file>]]
 		Existing POT file file whose content should be merged with the extracted strings.

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1222,6 +1222,11 @@ Feature: Generate a POT file of a WordPress plugin
       """
 
     When I run `wp i18n make-pot foo-plugin foo-plugin.pot --domain=bar`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
     And the foo-plugin.pot file should contain:
       """
       msgid "Foo"
@@ -1254,6 +1259,11 @@ Feature: Generate a POT file of a WordPress plugin
       """
 
     When I run `wp i18n make-pot foo-plugin foo-plugin.pot --skip-js`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
     And the foo-plugin.pot file should contain:
       """
       msgid "Foo Plugin"
@@ -1261,4 +1271,69 @@ Feature: Generate a POT file of a WordPress plugin
     And the foo-plugin.pot file should not contain:
       """
       msgid "Hello World"
+      """
+
+  Scenario: Extract all strings regardless of text domain
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
+
+       __( 'Hello World', 'foo-plugin' );
+
+       __( 'Foo', 'bar' );
+
+       __( 'bar' );
+      """
+    And a foo-plugin/foo-plugin.js file:
+      """
+      __( '__', 'foo-plugin' );
+
+      __( 'wrong-domain', 'wrong-domain' );
+
+      __( 'Hello JS' );
+      """
+
+    When I run `wp i18n make-pot foo-plugin foo-plugin.pot --domain=bar --ignore-domain`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "Foo"
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "bar"
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "__"
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "wrong-domain"
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "Hello JS"
       """

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -84,8 +84,8 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 				$all_comments[] = $comment;
 			}
 
-			$domain = $context = $original = $plural = null;
-			$args   = [];
+			$context = $plural = null;
+			$args    = [];
 
 			/** @var Node\Node $argument */
 			foreach ( $node->getArguments() as $argument ) {
@@ -106,39 +106,23 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 			switch ( $functions[ $callee->getName() ] ) {
 				case 'text_domain':
 				case 'gettext':
-					if ( ! isset( $args[1] ) ) {
-						break;
-					}
-
-					list( $original, $domain ) = $args;
+					list( $original, $domain ) = array_pad( $args, 2, null );
 					break;
 
 				case 'text_context_domain':
-					if ( ! isset( $args[2] ) ) {
-						break;
-					}
-
-					list( $original, $context, $domain ) = $args;
+					list( $original, $context, $domain ) = array_pad( $args, 3, null );
 					break;
 
 				case 'single_plural_number_domain':
-					if ( ! isset( $args[3] ) ) {
-						break;
-					}
-
-					list( $original, $plural, $number, $domain ) = $args;
+					list( $original, $plural, $number, $domain ) = array_pad( $args, 4, null );
 					break;
 
 				case 'single_plural_number_context_domain':
-					if ( ! isset( $args[4] ) ) {
-						break;
-					}
-
-					list( $original, $plural, $number, $context, $domain ) = $args;
+					list( $original, $plural, $number, $context, $domain ) = array_pad( $args, 5, null );
 					break;
 			}
 
-			if ( (string) $original !== '' && ( $domain === null || $domain === $translations->getDomain() ) ) {
+			if ( (string) $original !== '' && ( $domain === $translations->getDomain() || null === $translations->getDomain() ) ) {
 				$translation = $translations->insert( $context, $original, $plural );
 				$translation->addReference( $file, $node->getLocation()->getStart()->getLine() );
 

--- a/src/PhpFunctionsScanner.php
+++ b/src/PhpFunctionsScanner.php
@@ -20,56 +20,32 @@ final class PhpFunctionsScanner extends GettextPhpFunctionsScanner {
 				continue;
 			}
 
-			$domain = $context = $original = $plural = null;
+			$context = $plural = null;
 
 			switch ( $functions[ $name ] ) {
 				case 'text_domain':
 				case 'gettext':
-					if ( ! isset( $args[1] ) ) {
-						continue 2;
-					}
-
-					list( $original, $domain ) = $args;
+					list( $original, $domain ) = array_pad( $args, 2, null );
 					break;
 
 				case 'text_context_domain':
-					if ( ! isset( $args[2] ) ) {
-						continue 2;
-					}
-
-					list( $original, $context, $domain ) = $args;
+					list( $original, $context, $domain ) = array_pad( $args, 3, null );
 					break;
 
 				case 'single_plural_number_domain':
-					if ( ! isset( $args[3] ) ) {
-						continue 2;
-					}
-
-					list( $original, $plural, $number, $domain ) = $args;
+					list( $original, $plural, $number, $domain ) = array_pad( $args, 4, null );
 					break;
 
 				case 'single_plural_number_context_domain':
-					if ( ! isset( $args[4] ) ) {
-						continue 2;
-					}
-
-					list( $original, $plural, $number, $context, $domain ) = $args;
+					list( $original, $plural, $number, $context, $domain ) = array_pad( $args, 5, null );
 					break;
 
 				case 'single_plural_domain':
-					if ( ! isset( $args[2] ) ) {
-						continue 2;
-					}
-
-					list( $original, $plural, $domain ) = $args;
+					list( $original, $plural, $domain ) = array_pad( $args, 3, null );
 					break;
 
 				case 'single_plural_context_domain':
-					if ( ! isset( $args[3] ) ) {
-						continue 2;
-					}
-
-					list( $original, $plural, $context, $domain ) = $args;
+					list( $original, $plural, $context, $domain ) = array_pad( $args, 4, null );
 					break;
 
 				default:
@@ -77,7 +53,7 @@ final class PhpFunctionsScanner extends GettextPhpFunctionsScanner {
 					\WP_CLI::error( sprintf( "Internal error: unknown function map '%s' for '%s'.", $functions[ $name ], $name ) );
 			}
 
-			if ( (string) $original !== '' && ( $domain === null || $domain === $translations->getDomain() ) ) {
+			if ( (string) $original !== '' && ( $domain === $translations->getDomain() || null === $translations->getDomain() ) ) {
 				$translation = $translations->insert( $context, $original, $plural );
 				$translation = $translation->addReference( $file, $line );
 


### PR DESCRIPTION
This even allows extracting strings without any domain, which wasn't possible before.

That would be useful for projects like core (see #36) and private projects that aren't on WordPress.org.

Fixes #35.