### PR TITLE
Add `@when before_wp_load` to command namespace

### DIFF
--- a/src/CommandNamespace.php
+++ b/src/CommandNamespace.php
@@ -12,6 +12,7 @@ use WP_CLI\Dispatcher\CommandNamespace as BaseCommandNamespace;
  *     # Create a POT file for the WordPress plugin/theme in the current directory
  *     $ wp i18n make-pot . languages/my-plugin.pot
  *
+ * @when before_wp_load
  */
 class CommandNamespace extends BaseCommandNamespace {
 }


### PR DESCRIPTION
Before this PR:

```bash
$ wp i18n
Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can’t contact the database server at `localhost`. This could mean your host’s database server is down.
```

With this PR:

```bash
$ wp i18n
usage: wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--merge[=<file>]] [--exclude=<paths>] [--skip-js]

See 'wp help i18n <command>' for more information on a specific command.
```

Fixes #40.
