### PR TITLE
Text domain header

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Scans PHP and JavaScript files, as well as theme stylesheets for translatable st
 		Plugin or theme slug. Defaults to the source directory's basename.
 
 	[--domain=<domain>]
-		Text domain to look for in the source code. Defaults to the plugin/theme slug, unless the `--ignore-domain` option is used.
+		Text domain to look for in the source code, unless the `--ignore-domain` option is used.
+		By default, the "Text Domain" header of the plugin or theme is used.
+		If none is provided, it falls back to the plugin/theme slug.
 
 	[--ignore-domain]
 		Ignore the text domain completely and extract strings with any text domain.

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -239,6 +239,46 @@ Feature: Generate a POT file of a WordPress plugin
     And STDERR should be empty
     And the foo-plugin/languages/foo-plugin.pot file should exist
 
+  Scenario: Uses Text Domain header when no domain is set.
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: bar-plugin
+       * Domain Path: /languages
+       */
+
+       __( 'Foo Text', 'foo-plugin' );
+
+       __( 'Bar Text', 'bar-plugin' );
+      """
+
+    When I run `wp i18n make-pot foo-plugin foo-plugin.pot`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the foo-plugin.pot file should exist
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "Bar Text"
+      """
+    And the foo-plugin.pot file should not contain:
+      """
+      msgid "Foo Text"
+      """
+
   Scenario: Extract all supported functions
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -127,11 +127,11 @@ class MakePotCommand extends WP_CLI_Command {
 		}
 
 		// Determine destination.
-		$this->destination = $this->source . DIRECTORY_SEPARATOR . $this->slug . '.pot';
+		$this->destination = "{$this->source}/{$this->slug}.pot";
 
 		if ( ! empty( $file_data['Domain Path'] ) ) {
 			// Domain Path inside source folder.
-			$this->destination = $this->source . DIRECTORY_SEPARATOR . $file_data['Domain Path'] . DIRECTORY_SEPARATOR . $this->slug . '.pot';
+			$this->destination = sprintf( '%s/%s/%s.pot', $this->source, $file_data['Domain Path'], $this->slug );
 		}
 
 		if ( isset( $args[1] ) ) {

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -127,18 +127,15 @@ class MakePotCommand extends WP_CLI_Command {
 		}
 
 		// Determine destination.
+		$this->destination = $this->source . DIRECTORY_SEPARATOR . $this->slug . '.pot';
+
+		if ( ! empty( $file_data['Domain Path'] ) ) {
+			// Domain Path inside source folder.
+			$this->destination = $this->source . DIRECTORY_SEPARATOR . $file_data['Domain Path'] . DIRECTORY_SEPARATOR . $this->slug . '.pot';
+		}
+
 		if ( isset( $args[1] ) ) {
 			$this->destination = $args[1];
-		} else {
-			$file_data = $this->get_main_file_data();
-
-			// Current directory.
-			$this->destination = $this->slug . '.pot';
-
-			if ( isset( $file_data['Domain Path'] ) ) {
-				// Domain Path inside source folder.
-				$this->destination = $this->source . DIRECTORY_SEPARATOR . $file_data['Domain Path'] . DIRECTORY_SEPARATOR . $this->slug . '.pot';
-			}
 		}
 
 		// Two is_dir() checks in case of a race condition.


### PR DESCRIPTION
Fixes #41.

Note: while working on this I uncovered a bug in the destination file determination.

It previously used `isset()` to check whether the `Domain Path` header was present. However, it is _always_ set, but can be empty.

This meant that the default value, `$this->destination = $this->slug . '.pot';` was never used. Also, that default value is wrong anyway as it doesn't generate the POT file in the plugin's directory, but the current working dir.