### PR TITLE
Add --headers parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Scans PHP and JavaScript files, as well as theme stylesheets for translatable st
 		By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
 		Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
 
+	[--headers=<headers>]
+		Array in JSON format of custom headers which will be added to the POT file. Defaults to empty array.
+
 	[--skip-js]
 		Skips JavaScript string extraction. Useful when this is done in another build step, e.g. through Babel.
 

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
     },
     "require": {
         "gettext/gettext": "dev-master#37882dc3b58c2357fc6ddc204c1f22f7bb2b6601",
-        "mck89/peast": "^1.8"
+        "mck89/peast": "^1.8",
+        "wp-cli/wp-cli": "dev-master"
     },
     "require-dev": {
-        "wp-cli/wp-cli": "^1.1.0",
         "behat/behat": "~2.5"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
     },
     "require": {
         "gettext/gettext": "dev-master#37882dc3b58c2357fc6ddc204c1f22f7bb2b6601",
-        "mck89/peast": "^1.8",
-        "wp-cli/wp-cli": "dev-master"
+        "mck89/peast": "^1.8"
     },
     "require-dev": {
+        "wp-cli/wp-cli": "^1.1.0",
         "behat/behat": "~2.5"
     },
     "extra": {

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -99,6 +99,24 @@ Feature: Generate a POT file of a WordPress plugin
       "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/hello-world\n"
       """
 
+  Scenario: Sets custom Report-Msgid-Bugs-To
+    When I run `wp scaffold plugin hello-world`
+
+    When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot --headers='{"Report-Msgid-Bugs-To":"https://github.com/hello-world/hello-world/"}'`
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      "Report-Msgid-Bugs-To: https://github.com/hello-world/hello-world/\n"
+      """
+
+  Scenario: Sets custom header
+    When I run `wp scaffold plugin hello-world`
+
+    When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot --headers='{"X-Poedit-Basepath":".."}'`
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      "X-Poedit-Basepath: ..\n"
+      """
+
   Scenario: Sets the last translator and the language team
     When I run `wp scaffold plugin hello-world`
 

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -107,6 +107,10 @@ Feature: Generate a POT file of a WordPress plugin
       """
       "Report-Msgid-Bugs-To: https://github.com/hello-world/hello-world/\n"
       """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should not contain:
+      """
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/hello-world\n"
+      """
 
   Scenario: Sets custom header
     When I run `wp scaffold plugin hello-world`

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -110,9 +110,12 @@ class MakePotCommand extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function __invoke( $args, $assoc_args ) {
-		$this->source         = realpath( $args[0] );
-		$this->slug           = Utils\get_flag_value( $assoc_args, 'slug', Utils\basename( $this->source ) );
-		$this->skip_js        = Utils\get_flag_value( $assoc_args, 'skip-js', $this->skip_js );
+		$array_arguments = array( 'headers' );
+		$assoc_args      = \WP_CLI\Utils\parse_shell_arrays( $assoc_args, $array_arguments );
+		$this->source    = realpath( $args[0] );
+		$this->slug      = Utils\get_flag_value( $assoc_args, 'slug', Utils\basename( $this->source ) );
+		$this->skip_js   = Utils\get_flag_value( $assoc_args, 'skip-js', $this->skip_js );
+		$this->headers   = Utils\get_flag_value( $assoc_args, 'headers', $this->headers );
 
 		$ignore_domain = Utils\get_flag_value( $assoc_args, 'ignore-domain', false );
 
@@ -169,10 +172,6 @@ class MakePotCommand extends WP_CLI_Command {
 			$this->exclude = array_filter( array_merge( $this->exclude, explode( ',', $assoc_args['exclude'] ) ) );
 			$this->exclude = array_map( [ $this, 'unslashit' ], $this->exclude);
 			$this->exclude = array_unique( $this->exclude );
-		}
-
-		if ( isset( $assoc_args['headers'] ) ) {
-			$this->headers = json_decode( $assoc_args['headers'], true );
 		}
 
 		if ( ! $this->makepot() ) {


### PR DESCRIPTION
This PR resolves #47 by adding a `--headers` parameter which accepts a JSON-formatted array of custom header values which are added to the POT file. If custom headers are passed which correspond to defaults, the default values will be replaced.