### PR TITLE
WordPress Core support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ wp i18n
 Create a POT file for a WordPress plugin or theme.
 
 ~~~
-wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--ignore-domain] [--merge[=<file>]] [--exclude=<paths>] [--skip-js]
+wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--ignore-domain] [--merge[=<files>]] [--except=<files>] [--include=<paths>] [--exclude=<paths>] [--headers=<headers>] [--skip-js] [--copyright-holder=<name>] [--package-name=<name>]
 ~~~
 
 Scans PHP and JavaScript files, as well as theme stylesheets for translatable strings.
@@ -55,9 +55,16 @@ Scans PHP and JavaScript files, as well as theme stylesheets for translatable st
 	[--ignore-domain]
 		Ignore the text domain completely and extract strings with any text domain.
 
-	[--merge[=<file>]]
-		Existing POT file file whose content should be merged with the extracted strings.
+	[--merge[=<files>]]
+		One or more existing POT files whose contents should be merged with the extracted strings.
 		If left empty, defaults to the destination POT file.
+
+	[--except=<files>]
+		If set, only strings not already existing in one of the passed POT files will be extracted.
+
+	[--include=<paths>]
+		Only take specific files and folders into account for the string extraction.
+		Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
 
 	[--exclude=<paths>]
 		Include additional ignored paths as CSV (e.g. 'tests,bin,.github').
@@ -69,6 +76,12 @@ Scans PHP and JavaScript files, as well as theme stylesheets for translatable st
 
 	[--skip-js]
 		Skips JavaScript string extraction. Useful when this is done in another build step, e.g. through Babel.
+
+	[--copyright-holder=<name>]
+		Name to use for the copyright comment in the resulting POT file.
+
+	[--package-name=<name>]
+		Name to use for package name in the resulting POT file. Overrides anything found in a plugin or theme.
 
 **EXAMPLES**
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ wp i18n
 
 ### wp i18n make-pot
 
-Create a POT file for a WordPress plugin or theme.
+Create a POT file for a WordPress project.
 
 ~~~
-wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--ignore-domain] [--merge[=<files>]] [--except=<files>] [--include=<paths>] [--exclude=<paths>] [--headers=<headers>] [--skip-js] [--copyright-holder=<name>] [--package-name=<name>]
+wp i18n make-pot <source> [<destination>] [--slug=<slug>] [--domain=<domain>] [--ignore-domain] [--merge[=<paths>]] [--subtract=<paths>] [--include=<paths>] [--exclude=<paths>] [--headers=<headers>] [--skip-js] [--file-comment] [--package-name=<name>]
 ~~~
 
-Scans PHP and JavaScript files, as well as theme stylesheets for translatable strings.
+Scans PHP and JavaScript files for translatable strings, as well as theme stylesheets and plugin files
+if the source directory is detected as either a plugin or theme.
 
 **OPTIONS**
 
@@ -50,26 +51,34 @@ Scans PHP and JavaScript files, as well as theme stylesheets for translatable st
 	[--domain=<domain>]
 		Text domain to look for in the source code, unless the `--ignore-domain` option is used.
 		By default, the "Text Domain" header of the plugin or theme is used.
-		If none is provided, it falls back to the plugin/theme slug.
+		If none is provided, it falls back to the project slug.
 
 	[--ignore-domain]
 		Ignore the text domain completely and extract strings with any text domain.
 
-	[--merge[=<files>]]
-		One or more existing POT files whose contents should be merged with the extracted strings.
-		If left empty, defaults to the destination POT file.
+	[--merge[=<paths>]]
+		Comma-separated list of POT files whose contents should be merged with the extracted strings.
+		If left empty, defaults to the destination POT file. POT file headers will be ignored.
 
-	[--except=<files>]
-		If set, only strings not already existing in one of the passed POT files will be extracted.
+	[--subtract=<paths>]
+		Comma-separated list of POT files whose contents should act as some sort of blacklist for string extraction.
+		Any string which is found on that blacklist will not be extracted.
+		This can be useful when you want to create multiple POT files from the same source directory with slightly
+		different content and no duplicate strings between them.
 
 	[--include=<paths>]
-		Only take specific files and folders into account for the string extraction.
+		Comma-separated list of files and paths that should be used for string extraction.
+		If provided, only these files and folders will be taken into account for string extraction.
+		For example, `--include="src,my-file.php` will ignore anything besides `my-file.php` and files in the `src` directory.
+		Simple glob patterns can be used, i.e. `--include=foo-*.php` includes any PHP file with the `foo-` prefix.
 		Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
 
 	[--exclude=<paths>]
-		Include additional ignored paths as CSV (e.g. 'tests,bin,.github').
-		By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
+		Comma-separated list of files and paths that should be skipped for string extraction.
+		For example, `--exclude=".github,myfile.php` would ignore any strings found within `myfile.php` or the `.github` folder.
+		Simple glob patterns can be used, i.e. `--exclude=foo-*.php` excludes any PHP file with the `foo-` prefix.
 		Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
+		The following files and folders are always excluded: node_modules, .git, .svn, .CVS, .hg, vendor, *.min.js.
 
 	[--headers=<headers>]
 		Array in JSON format of custom headers which will be added to the POT file. Defaults to empty array.
@@ -77,16 +86,33 @@ Scans PHP and JavaScript files, as well as theme stylesheets for translatable st
 	[--skip-js]
 		Skips JavaScript string extraction. Useful when this is done in another build step, e.g. through Babel.
 
-	[--copyright-holder=<name>]
-		Name to use for the copyright comment in the resulting POT file.
+	[--file-comment]
+		String that should be added as a comment to the top of the resulting POT file.
+		By default, a copyright comment is added for WordPress plugins and themes in the following manner:
+
+		```
+		Copyright (C) 2018 Example Plugin Author
+		This file is distributed under the same license as the Example Plugin package.
+		```
+
+		If a plugin or theme specifies a license in their main plugin file or stylesheet, the comment looks like this:
+
+		```
+		Copyright (C) 2018 Example Plugin Author
+		This file is distributed under the GPLv2.
+		```
 
 	[--package-name=<name>]
-		Name to use for package name in the resulting POT file. Overrides anything found in a plugin or theme.
+		Name to use for package name in the resulting POT file's `Project-Id-Version` header.
+		Overrides plugin or theme name, if applicable.
 
 **EXAMPLES**
 
     # Create a POT file for the WordPress plugin/theme in the current directory
     $ wp i18n make-pot . languages/my-plugin.pot
+
+    # Create a POT file for the continents and cities list in WordPress core.
+    $ wp i18n make-pot . continents-and-cities.pot --include="wp-admin/includes/continents-cities.php" --ignore-domain
 
 ## Installing
 

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -178,24 +178,22 @@ Feature: Generate a POT file of a WordPress project
 
   Scenario: Bails when no plugin files are found
     Given an empty foo-plugin directory
-    When I try `wp i18n make-pot foo-plugin foo-plugin.pot`
+    When I try `wp i18n make-pot foo-plugin foo-plugin.pot --debug`
     Then STDERR should contain:
       """
-      Error: No valid theme stylesheet or plugin file found!
+      No valid theme stylesheet or plugin file found, treating as a regular project.
       """
-    And the return code should be 1
 
   Scenario: Bails when no main plugin file is found
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:
       """
       """
-    When I try `wp i18n make-pot foo-plugin foo-plugin.pot`
+    When I try `wp i18n make-pot foo-plugin foo-plugin.pot --debug`
     Then STDERR should contain:
       """
-      Error: No valid theme stylesheet or plugin file found!
+      No valid theme stylesheet or plugin file found, treating as a regular project.
       """
-    And the return code should be 1
 
   Scenario: Adds relative paths to source file as comments.
     Given an empty foo-plugin directory

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -952,6 +952,63 @@ Feature: Generate a POT file of a WordPress project
       I am not being ignored
       """
 
+  Scenario: Only extract strings from included paths
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
+       __( 'Hello World', 'foo-plugin' );
+      """
+    And a foo-plugin/vendor/ignored.php file:
+      """
+      <?php
+       __( 'I am being ignored', 'foo-plugin' );
+      """
+    And a foo-plugin/foo/file.php file:
+      """
+      <?php
+       __( 'I am included', 'foo-plugin' );
+      """
+    And a foo-plugin/bar/file.php file:
+      """
+      <?php
+       __( 'I am also included', 'foo-plugin' );
+      """
+    And a foo-plugin/baz/included.js file:
+      """
+      __( 'I am totally included', 'foo-plugin' );
+      """
+
+    When I run `wp i18n make-pot foo-plugin foo-plugin.pot --include=foo,bar,baz/inc*.js`
+    Then the foo-plugin.pot file should not contain:
+      """
+      I am being ignored
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      I am included
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      I am also included
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      I am totally included
+      """
+
   Scenario: Merges translations with the ones from an existing POT file
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.pot file:

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1002,6 +1002,85 @@ Feature: Generate a POT file of a WordPress project
       msgid "Foo Plugin"
       """
 
+  Scenario: Merges translations with the ones from multiple existing POT files
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr ""
+      """
+    And a foo-plugin/bar-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #: bar-plugin.js:15
+      msgid "Bar Plugin"
+      msgstr ""
+      """
+
+    When I run `wp scaffold plugin hello-world --plugin_name="Hello World" --plugin_author="John Doe" --plugin_author_uri="https://example.com" --plugin_uri="https://foo.example.com"`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+
+    When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot --merge=foo-plugin/foo-plugin.pot,foo-plugin/bar-plugin.pot`
+    Then the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      #: foo-plugin.js:15
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Foo Plugin"
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      #: bar-plugin.js:15
+      """
+    And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
+      """
+      msgid "Bar Plugin"
+      """
+
   Scenario: Merges translations with existing destination file
     When I run `wp scaffold plugin hello-world --plugin_name="Hello World" --plugin_author="John Doe" --plugin_author_uri="https://example.com" --plugin_uri="https://foo.example.com"`
     Then the wp-content/plugins/hello-world directory should exist

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -907,6 +907,51 @@ Feature: Generate a POT file of a WordPress project
       I am not being ignored either
       """
 
+  Scenario: Supports glob patterns for file exclusion
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
+       __( 'Hello World', 'foo-plugin' );
+      """
+    And a foo-plugin/sub/foobar.php file:
+      """
+      <?php
+       __( 'I am not being ignored', 'foo-plugin' );
+      """
+    And a foo-plugin/sub/foo-bar.php file:
+      """
+      <?php
+       __( 'I am being ignored', 'foo-plugin' );
+      """
+    And a foo-plugin/sub/foo-baz.php file:
+      """
+      <?php
+       __( 'I am being ignored', 'foo-plugin' );
+      """
+
+    When I run `wp i18n make-pot foo-plugin foo-plugin.pot --exclude="sub/foo-*.php"`
+    Then the foo-plugin.pot file should not contain:
+      """
+      I am being ignored
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      I am not being ignored
+      """
+
   Scenario: Merges translations with the ones from an existing POT file
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.pot file:

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1718,3 +1718,86 @@ Feature: Generate a POT file of a WordPress project
       """
       Extracted 2 strings
       """
+
+  Scenario: Ignore strings that are part of the exception list
+    Given an empty directory
+    And a exception.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      msgid "Foo Bar"
+      msgstr ""
+
+      msgid "Bar Baz"
+      msgstr ""
+
+      msgid "Some other text"
+      msgstr ""
+      """
+    And a foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
+
+       __( 'Hello World', 'foo-plugin' );
+
+       __( 'Foo Bar', 'foo-plugin' );
+
+       __( 'Bar Baz', 'foo-plugin' );
+
+       __( 'Some text', 'foo-plugin' );
+
+       __( 'Some other text', 'foo-plugin' );
+      """
+
+    When I run `wp i18n make-pot . foo-plugin.pot --domain=foo-plugin --except=exception.pot`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "Some text"
+      """
+    And the foo-plugin.pot file should not contain:
+      """
+      msgid "Foo Bar"
+      """
+    And the foo-plugin.pot file should not contain:
+      """
+      msgid "Bar Baz"
+      """
+    And the foo-plugin.pot file should not contain:
+      """
+      msgid "Some other text"
+      """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -77,8 +77,8 @@ Feature: Generate a POT file of a WordPress project
     When I run `wp i18n make-pot wp-content/plugins/hello-world wp-content/plugins/hello-world/languages/hello-world.pot`
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
       """
-      # Copyright (C) {YEAR} Hello World
-      # This file is distributed under the same license as the Hello World package.
+      # Copyright (C) {YEAR} YOUR NAME HERE
+      # This file is distributed under the same license as the Hello World plugin.
       """
 
   Scenario: Sets Project-Id-Version
@@ -1353,8 +1353,8 @@ Feature: Generate a POT file of a WordPress project
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should contain:
       """
-      # Copyright (C) 2018 Hello World
-      # This file is distributed under the same license as the Hello World package.
+      # Copyright (C) 2018 John Doe
+      # This file is distributed under the same license as the Hello World plugin.
       msgid ""
       msgstr ""
       "Project-Id-Version: Hello World 0.1.0\n"
@@ -1902,7 +1902,7 @@ Feature: Generate a POT file of a WordPress project
        __( 'Some other text', 'foo-plugin' );
       """
 
-    When I run `wp i18n make-pot . foo-plugin.pot --domain=foo-plugin --except=exception.pot`
+    When I run `wp i18n make-pot . foo-plugin.pot --domain=foo-plugin --subtract=exception.pot`
     Then STDOUT should be:
       """
       Plugin file detected.
@@ -1965,7 +1965,7 @@ Feature: Generate a POT file of a WordPress project
       msgid "Bar"
       """
 
-  Scenario: Customized copyright notice
+  Scenario: Custom package name
     Given an empty example-project directory
     And a example-project/stuff.php file:
       """
@@ -1978,17 +1978,36 @@ Feature: Generate a POT file of a WordPress project
        __( 'Bar' );
       """
 
-    When I run `date +"%Y"`
-    Then STDOUT should not be empty
-    And save STDOUT as {YEAR}
+    When I run `wp i18n make-pot example-project result.pot --ignore-domain --package-name="Acme 1.2.3"`
+    Then STDOUT should be:
+      """
+      Success: POT file successfully generated!
+      """
+    And the result.pot file should contain:
+      """
+      Project-Id-Version: Acme 1.2.3
+      """
 
-    When I run `wp i18n make-pot example-project result.pot --ignore-domain --copyright-holder="John Doe" --package-name="Acme"`
+  Scenario: Customized file comment
+    Given an empty example-project directory
+    And a example-project/stuff.php file:
+      """
+      <?php
+
+       __( 'Hello World' );
+
+       __( 'Foo' );
+
+       __( 'Bar' );
+      """
+
+    When I run `wp i18n make-pot example-project result.pot --ignore-domain --file-comment="Copyright (C) 2018 John Doe\nPowered by WP-CLI."`
     Then STDOUT should be:
       """
       Success: POT file successfully generated!
       """
     And the result.pot file should contain:
        """
-      # Copyright (C) {YEAR} John Doe
-      # This file is distributed under the same license as the Acme package.
+      # Copyright (C) 2018 John Doe
+      # Powered by WP-CLI.
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1801,3 +1801,38 @@ Feature: Generate a POT file of a WordPress project
       """
       msgid "Some other text"
       """
+
+  Scenario: Extract strings for a generic project
+    Given an empty example-project directory
+    And a example-project/stuff.php file:
+      """
+      <?php
+
+       __( 'Hello World' );
+
+       __( 'Foo' );
+
+       __( 'Bar' );
+      """
+
+    When I try `wp i18n make-pot example-project result.pot --ignore-domain --debug`
+    Then STDOUT should be:
+      """
+      Success: POT file successfully generated!
+      """
+    And STDERR should contain:
+      """
+      No valid theme stylesheet or plugin file found, treating as a regular project.
+      """
+    And the result.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the result.pot file should contain:
+      """
+      msgid "Foo"
+      """
+    And the result.pot file should contain:
+      """
+      msgid "Bar"
+      """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -221,7 +221,7 @@ Feature: Generate a POT file of a WordPress project
       """
 
     When I run `wp i18n make-pot foo-plugin foo-plugin.pot`
-    And the foo-plugin.pot file should contain:
+    Then the foo-plugin.pot file should contain:
       """
       #: foo-plugin.php:15
       """
@@ -1835,4 +1835,32 @@ Feature: Generate a POT file of a WordPress project
     And the result.pot file should contain:
       """
       msgid "Bar"
+      """
+
+  Scenario: Customized copyright notice
+    Given an empty example-project directory
+    And a example-project/stuff.php file:
+      """
+      <?php
+
+       __( 'Hello World' );
+
+       __( 'Foo' );
+
+       __( 'Bar' );
+      """
+
+    When I run `date +"%Y"`
+    Then STDOUT should not be empty
+    And save STDOUT as {YEAR}
+
+    When I run `wp i18n make-pot example-project result.pot --ignore-domain --copyright-holder="John Doe" --package-name="Acme"`
+    Then STDOUT should be:
+      """
+      Success: POT file successfully generated!
+      """
+    And the result.pot file should contain:
+       """
+      # Copyright (C) {YEAR} John Doe
+      # This file is distributed under the same license as the Acme package.
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -629,7 +629,7 @@ Feature: Generate a POT file of a WordPress project
       /**
        * Plugin Name: Foo Plugin
        * Plugin URI:  https://example.com
-       * Description:
+       * Description: Plugin Description
        * Version:     0.1.0
        * Author:
        * Author URI:
@@ -646,7 +646,16 @@ Feature: Generate a POT file of a WordPress project
        __( 'I am being ignored', 'foo-plugin' );
       """
 
-    When I run `wp i18n make-pot foo-plugin foo-plugin.pot`
+    When I try `wp i18n make-pot foo-plugin foo-plugin.pot --debug`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should contain:
+      """
+      Extracted 4 strings
+      """
     Then the foo-plugin.pot file should not contain:
       """
       I am being ignored

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1936,11 +1936,11 @@ Feature: Generate a POT file of a WordPress project
       """
       <?php
 
-       __( 'Hello World' );
+       _( 'Hello World' );
 
-       __( 'Foo' );
+       _( 'Foo' );
 
-       __( 'Bar' );
+       _( 'Bar' );
       """
 
     When I try `wp i18n make-pot example-project result.pot --ignore-domain --debug`

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -107,10 +107,10 @@ trait IterableCodeExtractor {
 
 			// Check for more complex paths, e.g. /some/sub/folder.
 			foreach ( $include as $path_or_file ) {
-				$pattern = preg_quote( str_replace( '*', '__wildcard__', '/' . $path_or_file ) );
-				$pattern = str_replace( '__wildcard__', '(.+)', $pattern );
+				$pattern = preg_quote( str_replace( '*', '__wildcard__', $path_or_file ) );
+				$pattern = '/' . str_replace( '__wildcard__', '(.+)', $pattern ) . '$';
 
-				if ( false !== mb_ereg( $pattern . '$', $file->getPathname() ) ) {
+				if ( false !== mb_ereg( $pattern, $file->getPathname() ) ) {
 					$is_valid = true;
 				}
 			}
@@ -121,17 +121,16 @@ trait IterableCodeExtractor {
 		}
 
 		if ( ! empty( $exclude ) ) {
-
 			if ( in_array( $file->getBasename(), $exclude, true ) ) {
 				return false;
 			}
 
 			// Check for more complex paths, e.g. /some/sub/folder.
 			foreach ( $exclude as $path_or_file ) {
-				$pattern = preg_quote( str_replace( '*', '__wildcard__', '/' . $path_or_file ) );
-				$pattern = str_replace( '__wildcard__', '(.+)', $pattern );
+				$pattern = preg_quote( str_replace( '*', '__wildcard__', $path_or_file ) );
+				$pattern = '/' . str_replace( '__wildcard__', '(.+)', $pattern ) . '$';
 
-				if ( false !== mb_ereg( $pattern . '$', $file->getPathname() ) ) {
+				if ( false !== mb_ereg( $pattern, $file->getPathname() ) ) {
 					return false;
 				}
 			}
@@ -159,15 +158,15 @@ trait IterableCodeExtractor {
 				function ( $file, $key, $iterator ) use ( $include, $exclude, $extensions ) {
 					/** @var SplFileInfo $file */
 
-					/** @var RecursiveCallbackFilterIterator $iterator */
-					if ( $iterator->hasChildren() ) {
-						return true;
-					}
-
 					$is_valid = static::isValidFile( $file, $include, $exclude );
 
 					if ( ! $is_valid ) {
 						return false;
+					}
+
+					/** @var RecursiveCallbackFilterIterator $iterator */
+					if ( $iterator->hasChildren() ) {
+						return true;
 					}
 
 					return ( $file->isFile() && in_array( $file->getExtension(), $extensions, true ) );

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -108,9 +108,12 @@ trait IterableCodeExtractor {
 		// Check for more complex paths, e.g. /some/sub/folder.
 		foreach ( $include as $path_or_file ) {
 			$pattern = preg_quote( str_replace( '*', '__wildcard__', $path_or_file ) );
-			$pattern = '/' . str_replace( '__wildcard__', '(.+)', $pattern ) . '$';
+			$pattern = '/' . str_replace( '__wildcard__', '(.+)', $pattern );
 
-			if ( false !== mb_ereg( $pattern, $file->getPathname() ) ) {
+			if (
+				false !== mb_ereg( $pattern, $file->getPathname() . '$' ) &&
+				false !== mb_ereg( $pattern, $file->getPathname() . '/' )
+			) {
 				return true;
 			}
 		}
@@ -167,14 +170,11 @@ trait IterableCodeExtractor {
 					/** @var RecursiveCallbackFilterIterator $iterator */
 					/** @var SplFileInfo $file */
 
-					$is_included = static::isIncluded( $file, $include );
-					$is_excluded = static::isExcluded( $file, $exclude );
-
-					if ( $is_excluded ) {
+					if ( static::isExcluded( $file, $exclude ) ) {
 						return false;
 					}
 
-					if ( ! $is_included && ! $iterator->hasChildren() ) {
+					if ( ! static::isIncluded( $file, $include ) && ! $iterator->hasChildren() ) {
 						return false;
 					}
 

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -107,7 +107,10 @@ trait IterableCodeExtractor {
 
 			// Check for more complex paths, e.g. /some/sub/folder.
 			foreach ( $include as $path_or_file ) {
-				if ( false !== mb_ereg( preg_quote( '/' . $path_or_file ) . '$', $file->getPathname() ) ) {
+				$pattern = preg_quote( str_replace( '*', '__wildcard__', '/' . $path_or_file ) );
+				$pattern = str_replace( '__wildcard__', '(.+)', $pattern );
+
+				if ( false !== mb_ereg( $pattern . '$', $file->getPathname() ) ) {
 					$is_valid = true;
 				}
 			}
@@ -125,7 +128,10 @@ trait IterableCodeExtractor {
 
 			// Check for more complex paths, e.g. /some/sub/folder.
 			foreach ( $exclude as $path_or_file ) {
-				if ( false !== mb_ereg( preg_quote( '/' . $path_or_file ) . '$', $file->getPathname() ) ) {
+				$pattern = preg_quote( str_replace( '*', '__wildcard__', '/' . $path_or_file ) );
+				$pattern = str_replace( '__wildcard__', '(.+)', $pattern );
+
+				if ( false !== mb_ereg( $pattern . '$', $file->getPathname() ) ) {
 					return false;
 				}
 			}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -154,8 +154,8 @@ class MakePotCommand extends WP_CLI_Command {
 		$this->slug             = Utils\get_flag_value( $assoc_args, 'slug', Utils\basename( $this->source ) );
 		$this->skip_js          = Utils\get_flag_value( $assoc_args, 'skip-js', $this->skip_js );
 		$this->headers          = Utils\get_flag_value( $assoc_args, 'headers', $this->headers );
-		$this->package_name     = Utils\get_flag_value( $assoc_args, 'package-name', $this->headers );
-		$this->copyright_holder = Utils\get_flag_value( $assoc_args, 'copyright-holder', $this->headers );
+		$this->package_name     = Utils\get_flag_value( $assoc_args, 'package-name', 'Unknown' );
+		$this->copyright_holder = Utils\get_flag_value( $assoc_args, 'copyright-holder', 'Unknown' );
 
 		$ignore_domain = Utils\get_flag_value( $assoc_args, 'ignore-domain', false );
 
@@ -458,8 +458,8 @@ class MakePotCommand extends WP_CLI_Command {
 	protected function get_file_comment() {
 		$file_data = $this->get_main_file_data();
 
-		$author = 'Unknown';
-		$name   = 'Unknown';
+		$author = $this->copyright_holder;
+		$name   = $this->package_name;
 
 		if ( isset( $file_data['Theme Name'] ) ) {
 			$name   = $file_data['Theme Name'];
@@ -469,8 +469,8 @@ class MakePotCommand extends WP_CLI_Command {
 			$author = $name;
 		}
 
-		$author = null !== $this->copyright_holder ? $this->copyright_holder : $author;
-		$name   = null !== $this->package_name ? $this->package_name : $name;
+		$author = null === $author ? $this->copyright_holder : $author;
+		$name   = null === $name ? $this->package_name : $name;
 
 		if ( isset( $file_data['License'] ) ) {
 			return sprintf(
@@ -495,7 +495,7 @@ class MakePotCommand extends WP_CLI_Command {
 	protected function set_default_headers() {
 		$file_data = $this->get_main_file_data();
 
-		$name         = 'Unknown';
+		$name         = $this->package_name;
 		$version      = $this->get_wp_version();
 		$bugs_address = null;
 
@@ -511,7 +511,7 @@ class MakePotCommand extends WP_CLI_Command {
 			$bugs_address = sprintf( 'https://wordpress.org/support/plugin/%s', $this->slug );
 		}
 
-		$name = null !== $this->package_name ? $this->package_name : $name;
+		$name = null === $name ? $this->package_name : $name;
 
 		$this->translations->setHeader( 'Project-Id-Version', $name . ( $version ? ' ' . $version : '' ) );
 

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -466,12 +466,14 @@ class MakePotCommand extends WP_CLI_Command {
 			WP_CLI::error( $e->getMessage() );
 		}
 
-		foreach( $this->translations as $translation ) {
-			/** @var Translation $translation */
-
-			if ( $this->exceptions->find( $translation ) ) {
+		foreach( $this->exceptions as $translation ) {
+			if ( $this->translations->find( $translation ) ) {
 				unset( $this->translations[ $translation->getId() ] );
 			}
+		}
+
+		foreach( $this->translations as $translation ) {
+			/** @var Translation $translation */
 
 			if ( ! $translation->hasExtractedComments() ) {
 				continue;

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -41,7 +41,7 @@ class MakePotCommand extends WP_CLI_Command {
 	/**
 	 * @var array
 	 */
-	protected $exclude = [ 'node_modules', '.git', '.svn', '.CVS', '.hg', 'vendor', 'Gruntfile.js', 'webpack.config.js' ];
+	protected $exclude = [ 'node_modules', '.git', '.svn', '.CVS', '.hg', 'vendor', 'Gruntfile.js', 'webpack.config.js', '*.min.js' ];
 
 	/**
 	 * @var string

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -71,12 +71,12 @@ class MakePotCommand extends WP_CLI_Command {
 	/**
 	 * @var string
 	 */
-	protected $copyright_holder;
+	protected $package_name;
 
 	/**
 	 * @var string
 	 */
-	protected $package_name;
+	protected $file_comment;
 
 	/**
 	 * These Regexes copied from http://php.net/manual/en/function.sprintf.php#93552
@@ -125,9 +125,10 @@ class MakePotCommand extends WP_CLI_Command {
 	)/x';
 
 	/**
-	 * Create a POT file for a WordPress plugin or theme.
+	 * Create a POT file for a WordPress project.
 	 *
-	 * Scans PHP and JavaScript files, as well as theme stylesheets for translatable strings.
+	 * Scans PHP and JavaScript files for translatable strings, as well as theme stylesheets and plugin files
+	 * if the source directory is detected as either a plugin or theme.
 	 *
 	 * ## OPTIONS
 	 *
@@ -143,26 +144,34 @@ class MakePotCommand extends WP_CLI_Command {
 	 * [--domain=<domain>]
 	 * : Text domain to look for in the source code, unless the `--ignore-domain` option is used.
 	 * By default, the "Text Domain" header of the plugin or theme is used.
-	 * If none is provided, it falls back to the plugin/theme slug.
+	 * If none is provided, it falls back to the project slug.
 	 *
 	 * [--ignore-domain]
 	 * : Ignore the text domain completely and extract strings with any text domain.
 	 *
-	 * [--merge[=<files>]]
-	 * : One or more existing POT files whose contents should be merged with the extracted strings.
-	 * If left empty, defaults to the destination POT file.
+	 * [--merge[=<paths>]]
+	 * : Comma-separated list of POT files whose contents should be merged with the extracted strings.
+	 * If left empty, defaults to the destination POT file. POT file headers will be ignored.
 	 *
-	 * [--except=<files>]
-	 * : If set, only strings not already existing in one of the passed POT files will be extracted.
+	 * [--subtract=<paths>]
+	 * : Comma-separated list of POT files whose contents should act as some sort of blacklist for string extraction.
+	 * Any string which is found on that blacklist will not be extracted.
+	 * This can be useful when you want to create multiple POT files from the same source directory with slightly
+	 * different content and no duplicate strings between them.
 	 *
 	 * [--include=<paths>]
-	 * : Only take specific files and folders into account for the string extraction.
+	 * : Comma-separated list of files and paths that should be used for string extraction.
+	 * If provided, only these files and folders will be taken into account for string extraction.
+	 * For example, `--include="src,my-file.php` will ignore anything besides `my-file.php` and files in the `src` directory.
+	 * Simple glob patterns can be used, i.e. `--include=foo-*.php` includes any PHP file with the `foo-` prefix.
 	 * Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
 	 *
 	 * [--exclude=<paths>]
-	 * : Include additional ignored paths as CSV (e.g. 'tests,bin,.github').
-	 * By default, the following files and folders are ignored: node_modules, .git, .svn, .CVS, .hg, vendor.
+	 * : Comma-separated list of files and paths that should be skipped for string extraction.
+	 * For example, `--exclude=".github,myfile.php` would ignore any strings found within `myfile.php` or the `.github` folder.
+	 * Simple glob patterns can be used, i.e. `--exclude=foo-*.php` excludes any PHP file with the `foo-` prefix.
 	 * Leading and trailing slashes are ignored, i.e. `/my/directory/` is the same as `my/directory`.
+	 * The following files and folders are always excluded: node_modules, .git, .svn, .CVS, .hg, vendor, *.min.js.
 	 *
 	 * [--headers=<headers>]
 	 * : Array in JSON format of custom headers which will be added to the POT file. Defaults to empty array.
@@ -170,16 +179,33 @@ class MakePotCommand extends WP_CLI_Command {
 	 * [--skip-js]
 	 * : Skips JavaScript string extraction. Useful when this is done in another build step, e.g. through Babel.
 	 *
-	 * [--copyright-holder=<name>]
-	 * : Name to use for the copyright comment in the resulting POT file.
+	 * [--file-comment]
+	 * : String that should be added as a comment to the top of the resulting POT file.
+	 * By default, a copyright comment is added for WordPress plugins and themes in the following manner:
+	 *
+	 * 		```
+	 * 		Copyright (C) 2018 Example Plugin Author
+	 * 		This file is distributed under the same license as the Example Plugin package.
+	 * 		```
+	 *
+	 * 		If a plugin or theme specifies a license in their main plugin file or stylesheet, the comment looks like this:
+	 *
+	 * 		```
+	 * 		Copyright (C) 2018 Example Plugin Author
+	 * 		This file is distributed under the GPLv2.
+	 * 		```
 	 *
 	 * [--package-name=<name>]
-	 * : Name to use for package name in the resulting POT file. Overrides anything found in a plugin or theme.
+	 * : Name to use for package name in the resulting POT file's `Project-Id-Version` header.
+	 * Overrides plugin or theme name, if applicable.
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Create a POT file for the WordPress plugin/theme in the current directory
 	 *     $ wp i18n make-pot . languages/my-plugin.pot
+	 *
+	 *     # Create a POT file for the continents and cities list in WordPress core.
+	 *     $ wp i18n make-pot . continents-and-cities.pot --include="wp-admin/includes/continents-cities.php" --ignore-domain
 	 *
 	 * @when before_wp_load
 	 *
@@ -221,12 +247,12 @@ class MakePotCommand extends WP_CLI_Command {
 		$array_arguments = array( 'headers' );
 		$assoc_args      = Utils\parse_shell_arrays( $assoc_args, $array_arguments );
 
-		$this->source           = realpath( $args[0] );
-		$this->slug             = Utils\get_flag_value( $assoc_args, 'slug', Utils\basename( $this->source ) );
-		$this->skip_js          = Utils\get_flag_value( $assoc_args, 'skip-js', $this->skip_js );
-		$this->headers          = Utils\get_flag_value( $assoc_args, 'headers', $this->headers );
-		$this->package_name     = Utils\get_flag_value( $assoc_args, 'package-name', 'Unknown' );
-		$this->copyright_holder = Utils\get_flag_value( $assoc_args, 'copyright-holder', 'Unknown' );
+		$this->source       = realpath( $args[0] );
+		$this->slug         = Utils\get_flag_value( $assoc_args, 'slug', Utils\basename( $this->source ) );
+		$this->skip_js      = Utils\get_flag_value( $assoc_args, 'skip-js', $this->skip_js );
+		$this->headers      = Utils\get_flag_value( $assoc_args, 'headers', $this->headers );
+		$this->file_comment = Utils\get_flag_value( $assoc_args, 'file-comment' );
+		$this->package_name = Utils\get_flag_value( $assoc_args, 'package-name' );
 
 		$ignore_domain = Utils\get_flag_value( $assoc_args, 'ignore-domain', false );
 
@@ -313,8 +339,8 @@ class MakePotCommand extends WP_CLI_Command {
 
 		$this->exceptions = new Translations();
 
-		if ( isset( $assoc_args['except'] ) ) {
-			$exceptions = explode( ',', $assoc_args['except'] );
+		if ( isset( $assoc_args['subtract'] ) ) {
+			$exceptions = explode( ',', $assoc_args['subtract'] );
 
 			$exceptions = array_filter(
 				$exceptions,
@@ -367,8 +393,6 @@ class MakePotCommand extends WP_CLI_Command {
 
 	/**
 	 * Retrieves the main file data of the plugin or theme.
-	 *
-	 * @throws WP_CLI\ExitException
 	 *
 	 * @return array
 	 */
@@ -634,38 +658,50 @@ class MakePotCommand extends WP_CLI_Command {
 	/**
 	 * Returns the copyright comment for the given package.
 	 *
-	 * @return array Meta data.
+	 * @return string File comment.
 	 */
 	protected function get_file_comment() {
-		$author = $this->copyright_holder;
-		$name   = $this->package_name;
-
-		if ( isset( $this->main_file_data['Theme Name'] ) ) {
-			$name   = $this->main_file_data['Theme Name'];
-			$author = $this->main_file_data['Author'];
-		} elseif ( isset( $this->main_file_data['Plugin Name'] ) ) {
-			$name   = $this->main_file_data['Plugin Name'];
-			$author = $name;
+		if ( $this->file_comment ) {
+			return implode( "\n", explode( '\n', $this->file_comment ) );
 		}
 
-		$author = null === $author ? $this->copyright_holder : $author;
-		$name   = null === $name ? $this->package_name : $name;
+		if ( isset( $this->main_file_data['Theme Name'] ) ) {
+			if ( isset( $this->main_file_data['License'] ) ) {
+				return sprintf(
+					"Copyright (C) %1\$s %2\$s\nThis file is distributed under the %3\$s.",
+					date( 'Y' ),
+					$this->main_file_data['Author'],
+					$this->main_file_data['License']
+				);
+			}
 
-		if ( isset( $this->main_file_data['License'] ) ) {
 			return sprintf(
-				"Copyright (C) %1\$s %2\$s\nThis file is distributed under the %3\$s.",
+				"Copyright (C) %1\$s %2\$s\nThis file is distributed under the same license as the %3\$s theme.",
 				date( 'Y' ),
-				$author,
-				$this->main_file_data['License']
+				$this->main_file_data['Author'],
+				$this->main_file_data['Theme Name']
 			);
 		}
 
-		return sprintf(
-			"Copyright (C) %1\$s %2\$s\nThis file is distributed under the same license as the %3\$s package.",
-			date( 'Y' ),
-			$author,
-			$name
-		);
+		if ( isset( $this->main_file_data['Plugin Name'] ) ) {
+			if ( isset( $this->main_file_data['License'] ) ) {
+				return sprintf(
+					"Copyright (C) %1\$s %2\$s\nThis file is distributed under the %3\$s.",
+					date( 'Y' ),
+					$this->main_file_data['Author'],
+					$this->main_file_data['License']
+				);
+			}
+
+			return sprintf(
+				"Copyright (C) %1\$s %2\$s\nThis file is distributed under the same license as the %3\$s plugin.",
+				date( 'Y' ),
+				$this->main_file_data['Author'],
+				$this->main_file_data['Plugin Name']
+			);
+		}
+
+		return '';
 	}
 
 	/**
@@ -674,7 +710,7 @@ class MakePotCommand extends WP_CLI_Command {
 	 * @param Translations $translations Translations object.
 	 */
 	protected function set_default_headers( $translations ) {
-		$name         = $this->package_name;
+		$name         = null;
 		$version      = $this->get_wp_version();
 		$bugs_address = null;
 
@@ -690,9 +726,13 @@ class MakePotCommand extends WP_CLI_Command {
 			$bugs_address = sprintf( 'https://wordpress.org/support/plugin/%s', $this->slug );
 		}
 
-		$name = null === $name ? $this->package_name : $name;
+		if ( null !== $this->package_name ) {
+			$name = $this->package_name;
+		}
 
-		$translations->setHeader( 'Project-Id-Version', $name . ( $version ? ' ' . $version : '' ) );
+		if ( null !== $name ) {
+			$translations->setHeader( 'Project-Id-Version', $name . ( $version ? ' ' . $version : '' ) );
+		}
 
 		if ( null !== $bugs_address ) {
 			$translations->setHeader( 'Report-Msgid-Bugs-To', $bugs_address );

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -236,9 +236,9 @@ class MakePotCommand extends WP_CLI_Command {
 			$this->exclude = array_filter( array_merge( $this->exclude, explode( ',', $assoc_args['exclude'] ) ) );
 			$this->exclude = array_map( [ $this, 'unslashit' ], $this->exclude );
 			$this->exclude = array_unique( $this->exclude );
-
-			WP_CLI::debug( sprintf( 'Excluding the following files: %s', implode( ',', $this->exclude ) ), 'make-pot' );
 		}
+
+		WP_CLI::debug( sprintf( 'Excluding the following files: %s', implode( ',', $this->exclude ) ), 'make-pot' );
 	}
 
 	/**

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -248,8 +248,8 @@ class MakePotCommand extends WP_CLI_Command {
 				WP_CLI::debug(
 					sprintf(
 						'Merging with existing POT %s: %s',
-						implode( ',', $this->merge ),
-						WP_CLI\Utils\pluralize( 'file', count( $this->merge ) )
+						WP_CLI\Utils\pluralize( 'file', count( $this->merge ) ),
+						implode( ',', $this->merge )
 					),
 					'make-pot'
 				);


### PR DESCRIPTION
Changes in this PR:

* Allows passing more than one file to `--merge`
* Does not error when no plugin or theme file has been found
* Adds glob support to `--exclude` (see #45)
* Adds a new `--include` argument as an addition to `--exclude`
* Adds new `--copyright-holder` and `--package-name` arguments  
  These values are used for the copyright notice comment at the top of the POT file.
  The naming of the arguments and the usefulness of that comment as a whole should be discussed.
* Adds a new `--except` option that accepts one or more POT files  
  Strings that are on this "blacklist" won't be extracted

----

**To do:**

* [x] Add necessary features for supporting string extraction in WordPress core (and perhaps any other project)
* [x] Cover these new features in tests

----

The following commands can be used to generate the necessary POT files for WordPress core.

Note: the `Report-Msgid-Bugs-To` URL can be overridden using the `--header` argument.

**Continents & Cities**

```bash
wp i18n make-pot /path/to/wordpress/core /path/to/target/wp-tz.pot \
--include="wp-admin/includes/continents-cities.php" \
--package-name="WordPress" \
--copyright-holder="WordPress" \
--debug \
--skip-js \
--ignore-domain
```

**WordPress** (Development 4.9.x on translate.wordpress.org)

```bash
wp i18n make-pot /path/to/wordpress/core /path/to/target/wordpress.pot \
--exclude="wp-admin/*,wp-content/themes/*,wp-includes/class-pop3.php,wp-content/plugins/akismet/" \
--package-name="WordPress" \
--copyright-holder="WordPress" \
--debug \
--skip-js \
--ignore-domain
```

**Administration**

This one involves some more steps as it should include all files except for _WordPress_ and _Network Admin_  files. Also, the Hello Dolly plugin, which is bundled with WordPress core, needs to be translated as well.

1. Hello Dolly:

```bash
wp i18n make-pot /path/to/wordpress/core/wp-content/plugins /path/to/target/hello-dolly.pot \
--include="hello.php" \
--exclude="akismet" \
--debug \
--skip-js \
--ignore-domain
```

2. WordPress Administration

```bash
wp i18n make-pot /path/to/wordpress/core /path/to/target/wp-admin.pot \
--exclude="wp-admin/network/*,wp-admin/network.php,wp-admin/includes/class-wp-ms*,wp-admin/includes/network.php,wp-admin/includes/continents-cities.php" \
--include="wp-admin/*" \
--merge="/path/to/target/hello-dolly.pot" \
--except="/path/to/target/wp-frontend.pot" \
--package-name="WordPress" \
--copyright-holder="WordPress" \
--debug \
--skip-js \
--ignore-domain
```

**Network Admin**

```bash
wp i18n make-pot /path/to/wordpress/core /path/to/target/wp-network-admin.pot \
--include="wp-admin/network/*,wp-admin/network.php,wp-admin/includes/class-wp-ms*,wp-admin/includes/network.php" \
--except="/path/to/target/wp-frontend.pot,/path/to/target/wp-admin.pot" \
--package-name="WordPress" \
--copyright-holder="WordPress" \
--debug \
--skip-js \
--ignore-domain
```

----

Fixes #36.
Fixes #45.