### PR TITLE
fix deps and composer normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "require": {
         "gettext/gettext": "^4.6",
-        "mck89/peast": "^1.8"
+        "mck89/peast": "^1.8",
+        "wp-cli/wp-cli": "^2"
     },
     "require-dev": {
         "wp-cli/scaffold-command": "^1.2 || ^2",
-        "wp-cli/wp-cli": "^2",
         "wp-cli/wp-cli-tests": "^2.0.7"
     },
     "config": {


### PR DESCRIPTION
wp-cli/wp-cli moved to require section, additionally I run `composer normalize`.