### PR TITLE
Allow passing an empty file comment

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2011,3 +2011,33 @@ Feature: Generate a POT file of a WordPress project
       # Copyright (C) 2018 John Doe
       # Powered by WP-CLI.
       """
+
+  Scenario: Empty file comment
+    Given an empty example-project directory
+    And a example-project/stuff.php file:
+      """
+      <?php
+
+       /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
+
+       __( 'Hello World', 'foo-plugin' );
+      """
+
+    When I run `wp i18n make-pot example-project result.pot --ignore-domain --file-comment="d"`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And the contents of the result.pot file should match /^msgid/

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2034,7 +2034,7 @@ Feature: Generate a POT file of a WordPress project
        __( 'Hello World', 'foo-plugin' );
       """
 
-    When I run `wp i18n make-pot example-project result.pot --ignore-domain --file-comment="d"`
+    When I run `wp i18n make-pot example-project result.pot --ignore-domain --file-comment=""`
     Then STDOUT should be:
       """
       Plugin file detected.

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -652,7 +652,6 @@ class MakePotCommand extends WP_CLI_Command {
 				}
 			}
 		}
-
 	}
 
 	/**
@@ -661,7 +660,11 @@ class MakePotCommand extends WP_CLI_Command {
 	 * @return string File comment.
 	 */
 	protected function get_file_comment() {
-		if ( $this->file_comment ) {
+		if ( '' === $this->file_comment ) {
+			return '';
+		}
+
+		if ( isset( $this->file_comment ) ) {
 			return implode( "\n", explode( '\n', $this->file_comment ) );
 		}
 

--- a/src/PotGenerator.php
+++ b/src/PotGenerator.php
@@ -19,13 +19,15 @@ class PotGenerator extends Po {
 	 *
 	 * Doesn't need to include # in the beginning of lines, these are added automatically.
 	 *
-	 * @param array $comment
+	 * @param string $comment File comment.
 	 */
 	public static function setCommentBeforeHeaders( $comment ) {
 		$comments = explode( "\n", $comment );
 
 		foreach( $comments as $line ) {
-			static::$comments_before_headers[] = '# ' . $line;
+			if ( '' !== trim( $line ) ) {
+				static::$comments_before_headers[] = '# ' . $line;
+			}
 		}
 	}
 
@@ -33,6 +35,12 @@ class PotGenerator extends Po {
 	 * {@parentDoc}.
 	 */
 	public static function toString( Translations $translations, array $options = [] ) {
-		return implode( "\n", static::$comments_before_headers ) . "\n" . parent::toString( $translations, $options );
+		$result = '';
+
+		if ( ! empty( static::$comments_before_headers ) ) {
+			$result = implode( "\n", static::$comments_before_headers ) . "\n";
+		}
+
+		return $result . parent::toString( $translations, $options );
 	}
 }


### PR DESCRIPTION
Related: https://github.com/Automattic/amp-wp/issues/1416.

This change allows omitting the file comment at the top of the POT file to prevent issues with the pot-to-php script that Gutenberg and other plugins use.