### PR TITLE
Support parsing minified JS files created by WebPack

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1431,11 +1431,13 @@ Feature: Generate a POT file of a WordPress project
       );
 
       wp.i18n.__( 'wp.i18n.__', 'foo-plugin' );
+      wp.i18n._n( 'wp.i18n._n_single', 'wp.i18n._n_plural', number, 'foo-plugin' );
 
       const translate = wp.i18n;
       translate.__( 'translate.__', 'foo-plugin' );
 
       Object(u.__)( 'minified.__', 'foo-plugin' );
+      Object(j._x)( 'minified._x', 'minified._x_context', 'foo-plugin' );
       """
 
     When I run `wp i18n make-pot foo-plugin`
@@ -1487,11 +1489,27 @@ Feature: Generate a POT file of a WordPress project
       """
     And the foo-plugin/foo-plugin.pot file should contain:
       """
+      msgid "wp.i18n._n_single"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid_plural "wp.i18n._n_plural"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
       msgid "translate.__"
       """
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       msgid "minified.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "minified._x"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgctxt "minified._x_context"
       """
     And the foo-plugin/foo-plugin.pot file should not contain:
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1429,6 +1429,13 @@ Feature: Generate a POT file of a WordPress project
         <h1>{__( 'Hello JSX', 'foo-plugin' )}</h1>,
         document.getElementById('root')
       );
+
+      wp.i18n.__( 'wp.i18n.__', 'foo-plugin' );
+
+      const translate = wp.i18n;
+      translate.__( 'translate.__', 'foo-plugin' );
+
+      Object(u.__)( 'minified.__', 'foo-plugin' );
       """
 
     When I run `wp i18n make-pot foo-plugin`
@@ -1473,6 +1480,18 @@ Feature: Generate a POT file of a WordPress project
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       msgid "Hello JSX"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "wp.i18n.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "translate.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "minified.__"
       """
     And the foo-plugin/foo-plugin.pot file should not contain:
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1436,6 +1436,8 @@ Feature: Generate a POT file of a WordPress project
       const translate = wp.i18n;
       translate.__( 'translate.__', 'foo-plugin' );
 
+      Object(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_7__["__"])( 'webpack.__', 'foo-plugin' );
+
       Object(u.__)( 'minified.__', 'foo-plugin' );
       Object(j._x)( 'minified._x', 'minified._x_context', 'foo-plugin' );
       """
@@ -1498,6 +1500,10 @@ Feature: Generate a POT file of a WordPress project
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       msgid "translate.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "webpack.__"
       """
     And the foo-plugin/foo-plugin.pot file should contain:
       """

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -181,7 +181,7 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 			'CallExpression' ===  $node->getCallee()->getType() &&
 			'Identifier' ===  $node->getCallee()->getCallee()->getType() &&
 			'Object' === $node->getCallee()->getCallee()->getName() &&
-			! empty( $node->getCallee()->getArguments() ) &&
+			array() !== $node->getCallee()->getArguments() &&
 			'MemberExpression' === $node->getCallee()->getArguments()[0]->getType() &&
 			'Identifier' === $node->getCallee()->getArguments()[0]->getProperty()->getType()
 		) {

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -73,9 +73,17 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 			} else if (
 				'CallExpression' ===  $node->getCallee()->getType() &&
 				'Identifier' ===  $node->getCallee()->getCallee()->getType() &&
-				'Object' === $node->getCallee()->getCallee()->getName()
+				'Object' === $node->getCallee()->getCallee()->getName() &&
+				! empty( $node->getCallee()->getArguments() ) &&
+				'MemberExpression' === $node->getCallee()->getArguments()[0]->getType() &&
+				'Identifier' === $node->getCallee()->getArguments()[0]->getProperty()->getType()
 			) {
 				$callee = $node->getCallee()->getArguments()[0]->getProperty();
+			} else if (
+				'MemberExpression' === $node->getCallee()->getType() &&
+				'Identifier' === $node->getCallee()->getProperty()->getType()
+			) {
+				$callee = $node->getCallee()->getProperty();
 			}
 
 			if ( ! $callee || ! isset( $functions[ $callee->getName() ] ) ) {

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -160,32 +160,34 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 	 * @return Node\Identifier|bool The identifier if resolved. False if not.
 	 */
 	private function resolveExpressionCallee( Node\CallExpression $node ) {
+		$callee = $node->getCallee();
+
 		// If the callee is a simple identifier it can simply be returned.
 		// For example: __( "translation" ).
-		if ( 'Identifier' === $node->getCallee()->getType() ) {
-			return $node->getCallee();
+		if ( 'Identifier' === $callee->getType() ) {
+			return $callee;
 		}
 
 		// If the callee is a member expression resolve it to the property.
 		// For example: wp.i18n.__( "translation" ) or u.__( "translation" ).
 		if (
-			'MemberExpression' === $node->getCallee()->getType() &&
-			'Identifier' === $node->getCallee()->getProperty()->getType()
+			'MemberExpression' === $callee->getType() &&
+			'Identifier' === $callee->getProperty()->getType()
 		) {
-			return $node->getCallee()->getProperty();
+			return $callee->getProperty();
 		}
 
 		// If the callee is a call expression as created by Webpack resolve it.
 		// For example: Object(u.__)( "translation" ).
 		if (
-			'CallExpression' ===  $node->getCallee()->getType() &&
-			'Identifier' ===  $node->getCallee()->getCallee()->getType() &&
-			'Object' === $node->getCallee()->getCallee()->getName() &&
-			array() !== $node->getCallee()->getArguments() &&
-			'MemberExpression' === $node->getCallee()->getArguments()[0]->getType() &&
-			'Identifier' === $node->getCallee()->getArguments()[0]->getProperty()->getType()
+			'CallExpression' ===  $callee->getType() &&
+			'Identifier' ===  $callee->getCallee()->getType() &&
+			'Object' === $callee->getCallee()->getName() &&
+			array() !== $callee->getArguments() &&
+			'MemberExpression' === $callee->getArguments()[0]->getType() &&
+			'Identifier' === $callee->getArguments()[0]->getProperty()->getType()
 		) {
-			return $node->getCallee()->getArguments()[0]->getProperty();
+			return $callee->getArguments()[0]->getProperty();
 		}
 
 		// Unknown format.

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -183,7 +183,7 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 			'CallExpression' ===  $callee->getType() &&
 			'Identifier' ===  $callee->getCallee()->getType() &&
 			'Object' === $callee->getCallee()->getName() &&
-			array() !== $callee->getArguments() &&
+			[] !== $callee->getArguments() &&
 			'MemberExpression' === $callee->getArguments()[0]->getType() &&
 			'Identifier' === $callee->getArguments()[0]->getProperty()->getType()
 		) {

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -41,7 +41,7 @@ class MakePotCommand extends WP_CLI_Command {
 	/**
 	 * @var array
 	 */
-	protected $exclude = [ 'node_modules', '.git', '.svn', '.CVS', '.hg', 'vendor', 'Gruntfile.js', 'webpack.config.js', '*.min.js' ];
+	protected $exclude = [ 'node_modules', '.git', '.svn', '.CVS', '.hg', 'vendor', 'Gruntfile.js', 'webpack.config.js' ];
 
 	/**
 	 * @var string

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -41,7 +41,7 @@ class MakePotCommand extends WP_CLI_Command {
 	/**
 	 * @var array
 	 */
-	protected $exclude = [ 'node_modules', '.git', '.svn', '.CVS', '.hg', 'vendor', 'Gruntfile.js', 'webpack.config.js' ];
+	protected $exclude = [ 'node_modules', '.git', '.svn', '.CVS', '.hg', 'vendor', 'Gruntfile.js', 'webpack.config.js', '*.min.js' ];
 
 	/**
 	 * @var string


### PR DESCRIPTION
In order to resolve https://meta.trac.wordpress.org/ticket/3875 `wp i18n make-pot` should be able to traverse minified files created by WebPack in order to find where each translation is used, this so that when generating language packs it can generate a file for each JS file containing only the necessary translations.

Because WebPack wraps calls to `wp.i18n.__( "string" )` in the following form `Object(u.__)( "string" )` this adds support for `CallExpression`s where the callee is a `CallExpression` itself whose callee is `Object` and argument the necessary translation function.

This part will likely later need to be expanded to support more forms in which translations may be called. ~~Supporting `MemberExpression` as the callee for example would be an obvious first improvement.~~ Support for `MemberExpression` as the callee has been added in the PR.
