### PR TITLE
Replace regexes Peast can't parse.

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1474,7 +1474,7 @@ Feature: Generate a POT file of a WordPress project
       """
     And a foo-plugin/foo-plugin.js file:
       """
-      // Includes to test if peast correctly parses regexes containing a quote.
+      // Included to test if peast correctly parses regexes containing a quote.
       // See: https://github.com/wp-cli/i18n-command/issues/98
       n = n.replace(/"/g, '&quot;');
 

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1474,6 +1474,10 @@ Feature: Generate a POT file of a WordPress project
       """
     And a foo-plugin/foo-plugin.js file:
       """
+      // Includes to test if peast correctly parses regexes containing a quote.
+      // See: https://github.com/wp-cli/i18n-command/issues/98
+      n = n.replace(/"/g, '&quot;');
+
       __( '__', 'foo-plugin' );
       _x( '_x', '_x_context', 'foo-plugin' );
       _n( '_n_single', '_n_plural', number, 'foo-plugin' );

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -38,7 +38,7 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 	 */
 	public function saveGettextFunctions( Translations $translations, array $options ) {
 		// Replace unparseable regexes
-		$this->code = str_replace( '/"/g', '/\"/g', $this->code );
+		$this->code = str_replace( '/"/', '/\"/', $this->code );
 
 		$ast = Peast::latest( $this->code, [
 			'sourceType' => Peast::SOURCE_TYPE_MODULE,

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -37,7 +37,7 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 	 * {@inheritdoc}
 	 */
 	public function saveGettextFunctions( Translations $translations, array $options ) {
-		// Replace unparseable regexes
+		// Temporary workaround for https://github.com/wp-cli/i18n-command/issues/98.
 		$this->code = str_replace( '/"/', '/\"/', $this->code );
 
 		$ast = Peast::latest( $this->code, [

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -37,6 +37,9 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 	 * {@inheritdoc}
 	 */
 	public function saveGettextFunctions( Translations $translations, array $options ) {
+		// Replace unparseable regexes
+		$this->code = str_replace( '/"/g', '/\"/g', $this->code );
+
 		$ast = Peast::latest( $this->code, [
 			'sourceType' => Peast::SOURCE_TYPE_MODULE,
 			'comments'   => false !== $this->extractComments,


### PR DESCRIPTION
Fixes #98.

Currently only covers the simple `/"/` use-case which is the only one we're encountering right now.

Could be updated to use a regex to cover more complex scenarios but I'd prefer to avoid that. Should ideally be fixed in https://github.com/mck89/peast/issues/3.