### PR TITLE
Add parsing of .map files to improve reliability of JS translations

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1770,6 +1770,39 @@ Feature: Generate a POT file of a WordPress project
       msgid "Hello JSX"
       """
 
+  Scenario: Extract translator comments from JavaScript map file
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       */
+      """
+    And a foo-plugin/foo-plugin.js.map file:
+      """
+      {"version":3,"sources":["webpack:some-path/foo-plugin.js"],"sourcesContent":["/* Translators: foo */\n const foo = __( 'foo', 'foo-plugin' );"]}
+      """
+    When I try `wp i18n make-pot foo-plugin`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And the foo-plugin/foo-plugin.pot file should exist
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Foo Plugin"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "foo"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      #. Translators: foo
+      """
+
   Scenario: Skips JavaScript file altogether
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -554,6 +554,16 @@ class MakePotCommand extends WP_CLI_Command {
 						'extensions' => [ 'js' ],
 					]
 				);
+
+				MapCodeExtractor::fromDirectory(
+					$this->source,
+					$translations,
+					[
+						'include'    => $this->include,
+						'exclude'    => $this->exclude,
+						'extensions' => [ 'map' ],
+					]
+				);
 			}
 		} catch ( \Exception $e ) {
 			WP_CLI::error( $e->getMessage() );

--- a/src/MapCodeExtractor.php
+++ b/src/MapCodeExtractor.php
@@ -48,7 +48,7 @@ final class MapCodeExtractor extends JsCode {
 		} catch ( PeastException $e ) {
 			WP_CLI::debug(
 				sprintf(
-					'Could not parse file %1$s: %2$s (line %3$d, column %4$d)',
+					'Could not parse file %1$s.map: %2$s (line %3$d, column %4$d in the concatenated sourcesContent)',
 					$options['file'],
 					$e->getMessage(),
 					$e->getPosition()->getLine(),

--- a/src/MapCodeExtractor.php
+++ b/src/MapCodeExtractor.php
@@ -25,6 +25,11 @@ final class MapCodeExtractor extends JsCode {
 	 * {@inheritdoc}
 	 */
 	public static function fromString( $string, Translations $translations, array $options = [] ) {
+		if ( ! array_key_exists( 'file', $options ) || substr( $options['file'], -7 ) !==  '.js.map' ) {
+			return;
+		}
+		$options['file'] = substr( $options['file'], 0, -7 ) . '.js';
+
 		try {
 			$options += static::$options;
 
@@ -35,10 +40,6 @@ final class MapCodeExtractor extends JsCode {
 			}
 
 			$string = implode( "\n", $mapObject->sourcesContent );
-
-			if ( array_key_exists( 'file', $options ) ) {
-				$options['file'] = preg_replace( '/\.js\.map$/', '.js', $options['file'] );
-			}
 
 			$functions = new JsFunctionsScanner( $string );
 

--- a/src/MapCodeExtractor.php
+++ b/src/MapCodeExtractor.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WP_CLI\I18n;
+
+use Gettext\Extractors\JsCode;
+use Gettext\Translations;
+use Peast\Syntax\Exception as PeastException;
+use WP_CLI;
+
+final class MapCodeExtractor extends JsCode {
+	use IterableCodeExtractor;
+
+	public static $options = [
+		'extractComments' => [ 'translators', 'Translators' ],
+		'constants'       => [],
+		'functions'       => [
+			'__'  => 'text_domain',
+			'_x'  => 'text_context_domain',
+			'_n'  => 'single_plural_number_domain',
+			'_nx' => 'single_plural_number_context_domain',
+		],
+	];
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function fromString( $string, Translations $translations, array $options = [] ) {
+		try {
+			$options += static::$options;
+
+			$mapObject = json_decode( $string );
+
+			if ( ! isset( $mapObject->sourcesContent ) || ! is_array( $mapObject->sourcesContent ) ) {
+				return;
+			}
+
+			$string = implode( "\n", $mapObject->sourcesContent );
+
+			if ( array_key_exists( 'file', $options ) ) {
+				$options['file'] = preg_replace( '/\.js\.map$/', '.js', $options['file'] );
+			}
+
+			$functions = new JsFunctionsScanner( $string );
+
+			$functions->enableCommentsExtraction( $options['extractComments'] );
+			$functions->saveGettextFunctions( $translations, $options );
+		} catch ( PeastException $e ) {
+			WP_CLI::debug(
+				sprintf(
+					'Could not parse file %1$s: %2$s (line %3$d, column %4$d)',
+					$options['file'],
+					$e->getMessage(),
+					$e->getPosition()->getLine(),
+					$e->getPosition()->getColumn()
+				)
+			);
+		}
+	}
+}


### PR DESCRIPTION
Adds a new `MapCodeExtractor` to parse `.map` files ( that may accompany minified JS files ).

It will parse these using the existing `JsFunctionsScanner` to improve picking up translations and translator's comments that may get lost during build steps and/or minification.