### PR TITLE
Determine includes and excludes based on scores

### DIFF
--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -119,6 +119,7 @@ trait IterableCodeExtractor {
 				)
 			);
 			if ( $base_score === 0 ) {
+				// If the matcher is simply * it gets a score above the implicit score but below 1.
 				$base_score = 0.2;
 			}
 

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -112,6 +112,7 @@ trait IterableCodeExtractor {
 			$pattern = preg_quote( str_replace( '*', '__wildcard__', $path_or_file ) );
 			$pattern = '(^|/)' . str_replace( '__wildcard__', '(.+)', $pattern );
 
+			// Base score is the amount of nested directories, discounting wildcards.
 			$base_score = count(
 				array_filter(
 					explode( '/', $path_or_file ),
@@ -123,7 +124,7 @@ trait IterableCodeExtractor {
 				$base_score = 0.2;
 			}
 
-
+			// If the matcher contains no wildcards and matches the end of the path.
 			if (
 				false === strpos( $path_or_file, '*' ) &&
 				false !== mb_ereg( $pattern . '$', $root_relative_path )
@@ -131,6 +132,7 @@ trait IterableCodeExtractor {
 				return $base_score * 10;
 			}
 
+			// If the matcher matches the end of the path or a full directory contained.
 			if ( false !== mb_ereg( $pattern . '(/|$)', $root_relative_path ) ) {
 				return $base_score;
 			}
@@ -154,6 +156,7 @@ trait IterableCodeExtractor {
 		$root_relative_path = str_replace( static::$dir, '', $dir->getPathname() );
 
 		foreach ( $matchers as $path_or_file ) {
+			// If the matcher contains no wildcards and the path matches the start of the matcher.
 			if (
 				false === strpos( $path_or_file, '*' ) &&
 				0 === strpos( $path_or_file . '/', $root_relative_path )
@@ -163,6 +166,8 @@ trait IterableCodeExtractor {
 
 			$base = current( explode( '*', $path_or_file ) );
 
+			// If start of the path matches the start of the matcher until the first wildcard.
+			// Or the start of the matcher until the first wildcard matches the start of the path.
 			if (
 				0 === strpos( $base, $root_relative_path ) ||
 				0 === strpos( $root_relative_path, $base )

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -112,7 +112,16 @@ trait IterableCodeExtractor {
 			$pattern = preg_quote( str_replace( '*', '__wildcard__', $path_or_file ) );
 			$pattern = '(^|/)' . str_replace( '__wildcard__', '(.+)', $pattern );
 
-			$base_score = count( explode( '/', $path_or_file ) );
+			$base_score = count(
+				array_filter(
+					explode( '/', $path_or_file ),
+					function ( $component) { return $component !== '*'; }
+				)
+			);
+			if ( $base_score === 0 ) {
+				$base_score = 0.2;
+			}
+
 
 			if (
 				false === strpos( $path_or_file, '*' ) &&

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -75,7 +75,7 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_can_exclude_override_matching_directory() {
-		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], ['excluded'], [ 'php' ] );
+		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], ['foo/bar/excluded/*'], [ 'php' ] );
 		$expected_1 = static::$base . 'foo/bar/foo/bar/foo/bar/deep_directory_also_included.php';
 		$expected_2 = static::$base . 'foo/bar/excluded/excluded.js';
 		$this->assertContains( $expected_1, $result );
@@ -83,7 +83,7 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_can_not_exclude_partially_directory() {
-		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], ['exc'], [ 'js' ] );
+		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], [ 'exc' ], [ 'js' ] );
 		$expected_1 = static::$base . 'foo/bar/foo/bar/foo/bar/deep_directory_also_included.php';
 		$expected_2 = static::$base . 'foo/bar/excluded/ignored.js';
 		$this->assertNotContains( $expected_1, $result );

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -16,10 +16,15 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		 * PHP5.4 cannot set property with __DIR__ constant.
 		 */
 		self::$base = __DIR__ . '/data/';
+
+		$property = new \ReflectionProperty( 'WP_CLI\I18n\IterableCodeExtractor', 'dir' );
+		$property->setAccessible( true );
+		$property->setValue( null, self::$base );
+		$property->setAccessible( false );
 	}
 
 	public function test_can_include_files() {
-		$includes = [ 'foo', 'bar', 'baz/inc*.js' ];
+		$includes = [ 'foo-plugin', 'bar', 'baz/inc*.js' ];
 		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, [], [ 'php', 'js' ] );
 		$expected = static::$base . 'foo-plugin/foo-plugin.php';
 		$this->assertContains( $expected, $result );
@@ -78,31 +83,31 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_can_not_exclude_partially_directory() {
-		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], ['exc'], [ 'js' ] );
+		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], ['exc'], [ 'js' ] );
 		$expected_1 = static::$base . 'foo/bar/foo/bar/foo/bar/deep_directory_also_included.php';
 		$expected_2 = static::$base . 'foo/bar/excluded/ignored.js';
-		//$this->assertContains( $expected_1, $result );
+		$this->assertNotContains( $expected_1, $result );
 		$this->assertContains( $expected_2, $result );
 	}
 
-	public function test_can_exclude_by_wildcard() {
-		$result = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], [ '*' ], [ 'php', 'js' ] );
-		$this->assertEmpty( $result );
-	}
-
-	public function test_can_exclude_files() {
-		$excludes = [ 'hoge' ];
-		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], $excludes, [ 'php', 'js' ] );
-		$expected = static::$base . 'hoge/should_NOT_be_included.js';
-		$this->assertNotContains( $expected, $result );
-	}
-
-	public function test_can_override_exclude_by_include() {
-		// Overrides include option
-		$includes = [ 'excluded' ];
-		$excludes = [ 'excluded/ignored.js' ];
-		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
-		$expected = static::$base . 'foo/bar/excluded/ignored.js';
-		$this->assertContains( $expected, $result );
-	}
+//	public function test_can_exclude_by_wildcard() {
+//		$result = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], [ '*' ], [ 'php', 'js' ] );
+//		$this->assertEmpty( $result );
+//	}
+//
+//	public function test_can_exclude_files() {
+//		$excludes = [ 'hoge' ];
+//		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], $excludes, [ 'php', 'js' ] );
+//		$expected = static::$base . 'hoge/should_NOT_be_included.js';
+//		$this->assertNotContains( $expected, $result );
+//	}
+//
+//	public function test_can_override_exclude_by_include() {
+//		// Overrides include option
+//		$includes = [ 'excluded/ignored.js' ];
+//		$excludes = [ 'excluded/*.js' ];
+//		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
+//		$expected = static::$base . 'foo/bar/excluded/ignored.js';
+//		$this->assertContains( $expected, $result );
+//	}
 }

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -67,7 +67,7 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_can_exclude_override_wildcard() {
-		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], ['foo/bar/excluded/*'], [ 'php' ] );
+		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], [ 'foo/bar/excluded/*' ], [ 'php' ] );
 		$expected_1 = static::$base . 'foo/bar/foo/bar/foo/bar/deep_directory_also_included.php';
 		$expected_2 = static::$base . 'foo/bar/excluded/excluded.js';
 		$this->assertContains( $expected_1, $result );
@@ -75,7 +75,7 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_can_exclude_override_matching_directory() {
-		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], ['foo/bar/excluded/*'], [ 'php' ] );
+		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], [ 'foo/bar/excluded/*' ], [ 'php' ] );
 		$expected_1 = static::$base . 'foo/bar/foo/bar/foo/bar/deep_directory_also_included.php';
 		$expected_2 = static::$base . 'foo/bar/excluded/excluded.js';
 		$this->assertContains( $expected_1, $result );

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -83,31 +83,31 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_can_not_exclude_partially_directory() {
-		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], ['exc'], [ 'js' ] );
+		$result     = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ 'foo/bar/*' ], ['exc'], [ 'js' ] );
 		$expected_1 = static::$base . 'foo/bar/foo/bar/foo/bar/deep_directory_also_included.php';
 		$expected_2 = static::$base . 'foo/bar/excluded/ignored.js';
 		$this->assertNotContains( $expected_1, $result );
 		$this->assertContains( $expected_2, $result );
 	}
 
-//	public function test_can_exclude_by_wildcard() {
-//		$result = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], [ '*' ], [ 'php', 'js' ] );
-//		$this->assertEmpty( $result );
-//	}
-//
-//	public function test_can_exclude_files() {
-//		$excludes = [ 'hoge' ];
-//		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], $excludes, [ 'php', 'js' ] );
-//		$expected = static::$base . 'hoge/should_NOT_be_included.js';
-//		$this->assertNotContains( $expected, $result );
-//	}
-//
-//	public function test_can_override_exclude_by_include() {
-//		// Overrides include option
-//		$includes = [ 'excluded/ignored.js' ];
-//		$excludes = [ 'excluded/*.js' ];
-//		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
-//		$expected = static::$base . 'foo/bar/excluded/ignored.js';
-//		$this->assertContains( $expected, $result );
-//	}
+	public function test_can_exclude_by_wildcard() {
+		$result = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], [ '*' ], [ 'php', 'js' ] );
+		$this->assertEmpty( $result );
+	}
+
+	public function test_can_exclude_files() {
+		$excludes = [ 'hoge' ];
+		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, [], $excludes, [ 'php', 'js' ] );
+		$expected = static::$base . 'hoge/should_NOT_be_included.js';
+		$this->assertNotContains( $expected, $result );
+	}
+
+	public function test_can_override_exclude_by_include() {
+		// Overrides include option
+		$includes = [ 'excluded/ignored.js' ];
+		$excludes = [ 'excluded/*.js' ];
+		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
+		$expected = static::$base . 'foo/bar/excluded/ignored.js';
+		$this->assertContains( $expected, $result );
+	}
 }


### PR DESCRIPTION
Include and exclude matches are based on the strength of the match with:
1. path matches
2. filename matches
3. regex matches

Can probably use improvement but this should cover the base scenarios.