### PR TITLE
Normalize paths

### DIFF
--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -75,7 +75,9 @@ trait IterableCodeExtractor {
 	 * @return null
 	 */
 	public static function fromDirectory( $dir, Translations $translations, array $options = [] ) {
-		static::$dir = Utils\normalize_path( $dir );
+		$dir = Utils\normalize_path( $dir );
+
+		static::$dir = $dir;
 
 		$include = isset( $options['include'] ) ? $options['include'] : [];
 		$exclude = isset( $options['exclude'] ) ? $options['exclude'] : [];
@@ -225,7 +227,7 @@ trait IterableCodeExtractor {
 				continue;
 			}
 
-			$filtered_files[] = $file->getPathname();
+			$filtered_files[] = Utils\normalize_path( $file->getPathname() );
 		}
 
 		return $filtered_files;

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -7,9 +7,9 @@ use Gettext\Translations;
 use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use DirectoryIterator;
 use SplFileInfo;
 use WP_CLI;
+use WP_CLI\Utils;
 
 trait IterableCodeExtractor {
 
@@ -30,7 +30,7 @@ trait IterableCodeExtractor {
 	public static function fromFile( $file, Translations $translations, array $options = [] ) {
 		foreach ( static::getFiles( $file ) as $f ) {
 			// Make sure a relative file path is added as a comment.
-			$options['file'] = ltrim( str_replace( static::$dir, '', $f ), '/' );
+			$options['file'] = ltrim( str_replace( static::$dir, '', Utils\normalize_path( $f ) ), '/' );
 
 			$string = file_get_contents( $f );
 
@@ -75,7 +75,7 @@ trait IterableCodeExtractor {
 	 * @return null
 	 */
 	public static function fromDirectory( $dir, Translations $translations, array $options = [] ) {
-		static::$dir = $dir;
+		static::$dir = Utils\normalize_path( $dir );
 
 		$include = isset( $options['include'] ) ? $options['include'] : [];
 		$exclude = isset( $options['exclude'] ) ? $options['exclude'] : [];

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -196,7 +196,7 @@ trait IterableCodeExtractor {
 
 		$files = new RecursiveIteratorIterator(
 			new RecursiveCallbackFilterIterator(
-				new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS ),
+				new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::UNIX_PATHS ),
 				function ( $file, $key, $iterator ) use ( $include, $exclude, $extensions ) {
 					/** @var RecursiveCallbackFilterIterator $iterator */
 					/** @var SplFileInfo $file */

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -4,6 +4,7 @@ namespace WP_CLI\I18n\Tests;
 
 use PHPUnit_Framework_TestCase;
 use WP_CLI\I18n\IterableCodeExtractor;
+use WP_CLI\Utils;
 
 
 class Extractor_Test extends PHPUnit_Framework_TestCase {
@@ -15,7 +16,7 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		/**
 		 * PHP5.4 cannot set property with __DIR__ constant.
 		 */
-		self::$base = __DIR__ . '/data/';
+		self::$base = Utils\normalize_path( __DIR__ ) . '/data/';
 
 		$property = new \ReflectionProperty( 'WP_CLI\I18n\IterableCodeExtractor', 'dir' );
 		$property->setAccessible( true );


### PR DESCRIPTION
I have added two additional commits to #110 in order to get the PHPUnit test suite working on Windows.

The first commit modifies `getFilesFromDirectory` to use the `UNIX_PATHS` flag (see http://php.net/manual/en/class.filesystemiterator.php) to force the `RecursiveDirectoryIterator` to return Unix-style paths even on Windows.  (Note that `normalize_path` is already called at the end of the function to convert all paths to Unix-style; however, this occurs after the `RecursiveCallbackFilterIterator` has been used to filter the results.  Using the `UNIX_PATHS` flag ensures that the files inside the callback use Unix-style paths, which is necessary when comparing against `$include` and `$exclude`.)

The second commit just modifies the test suite to use a normalized base path.  With this change all the tests pass on Windows.