### PR TITLE
PHPCS: fix up the code base [1] - whitespace

### DIFF
--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -45,12 +45,12 @@ trait IterableCodeExtractor {
 				continue;
 			}
 
-			if ( ! empty ( $options['wpExtractTemplates'] ) ) {
+			if ( ! empty( $options['wpExtractTemplates'] ) ) {
 				$headers = MakePotCommand::get_file_data_from_string( $string, [ 'Template Name' => 'Template Name' ] );
 
-				if ( ! empty( $headers[ 'Template Name'])) {
-					$translation = new Translation( '', $headers[ 'Template Name'] );
-					$translation->addExtractedComment('Template Name of the theme' );
+				if ( ! empty( $headers['Template Name'] ) ) {
+					$translation = new Translation( '', $headers['Template Name'] );
+					$translation->addExtractedComment( 'Template Name of the theme' );
 
 					$translations[] = $translation;
 				}
@@ -118,7 +118,9 @@ trait IterableCodeExtractor {
 			$base_score = count(
 				array_filter(
 					explode( '/', $path_or_file ),
-					function ( $component) { return $component !== '*'; }
+					function ( $component ) {
+						return '*' !== $component;
+					}
 				)
 			);
 			if ( 0 === $base_score ) {

--- a/src/JedGenerator.php
+++ b/src/JedGenerator.php
@@ -16,7 +16,7 @@ class JedGenerator extends Jed {
 	 * {@parentDoc}.
 	 */
 	public static function toString( Translations $translations, array $options = [] ) {
-		$options  += static::$options;
+		$options += static::$options;
 		$domain   = $translations->getDomain() ?: 'messages';
 		$messages = static::buildMessages( $translations );
 

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -62,7 +62,7 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 			$file      = $options['file'];
 
 			/** @var Node\Node $node */
-			foreach( $node->getLeadingComments() as $comment ) {
+			foreach ( $node->getLeadingComments() as $comment ) {
 				$all_comments[] = $comment;
 			}
 
@@ -83,16 +83,17 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 				$argument->setLeadingComments( $argument->getLeadingComments() + $node->getLeadingComments() );
 			}
 
-			foreach( $callee['comments'] as $comment ) {
+			foreach ( $callee['comments'] as $comment ) {
 				$all_comments[] = $comment;
 			}
 
-			$context = $plural = null;
+			$context = null;
+			$plural  = null;
 			$args    = [];
 
 			/** @var Node\Node $argument */
 			foreach ( $node->getArguments() as $argument ) {
-				foreach( $argument->getLeadingComments() as $comment ) {
+				foreach ( $argument->getLeadingComments() as $comment ) {
 					$all_comments[] = $comment;
 				}
 
@@ -168,7 +169,7 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 		if ( 'Identifier' === $callee->getType() ) {
 			return [
 				'name'     => $callee->getName(),
-				'comments' => $callee->getLeadingComments()
+				'comments' => $callee->getLeadingComments(),
 			];
 		}
 
@@ -192,8 +193,8 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 		// If the callee is a call expression as created by Webpack resolve it.
 		// For example: Object(u.__)( "translation" ).
 		if (
-			'CallExpression' ===  $callee->getType() &&
-			'Identifier' ===  $callee->getCallee()->getType() &&
+			'CallExpression' === $callee->getType() &&
+			'Identifier' === $callee->getCallee()->getType() &&
 			'Object' === $callee->getCallee()->getName() &&
 			[] !== $callee->getArguments() &&
 			'MemberExpression' === $callee->getArguments()[0]->getType()

--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -93,8 +93,8 @@ class MakeJsonCommand extends WP_CLI_Command {
 
 		/** @var DirectoryIterator $file */
 		foreach ( $files as $file ) {
-			if ( $file->isFile() && $file->isReadable() && 'po' === $file->getExtension()) {
-				$result = $this->make_json( $file->getRealPath(), $destination );
+			if ( $file->isFile() && $file->isReadable() && 'po' === $file->getExtension() ) {
+				$result        = $this->make_json( $file->getRealPath(), $destination );
 				$result_count += count( $result );
 
 				if ( $purge ) {
@@ -107,7 +107,7 @@ class MakeJsonCommand extends WP_CLI_Command {
 			}
 		}
 
-		WP_CLI::success( sprintf( 'Created %d %s.', $result_count, Utils\pluralize( 'file', $result_count) ) );
+		WP_CLI::success( sprintf( 'Created %d %s.', $result_count, Utils\pluralize( 'file', $result_count ) ) );
 	}
 
 	/**

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -191,17 +191,17 @@ class MakePotCommand extends WP_CLI_Command {
 	 * : String that should be added as a comment to the top of the resulting POT file.
 	 * By default, a copyright comment is added for WordPress plugins and themes in the following manner:
 	 *
-	 * 		```
-	 * 		Copyright (C) 2018 Example Plugin Author
-	 * 		This file is distributed under the same license as the Example Plugin package.
-	 * 		```
+	 *      ```
+	 *      Copyright (C) 2018 Example Plugin Author
+	 *      This file is distributed under the same license as the Example Plugin package.
+	 *      ```
 	 *
-	 * 		If a plugin or theme specifies a license in their main plugin file or stylesheet, the comment looks like this:
+	 *      If a plugin or theme specifies a license in their main plugin file or stylesheet, the comment looks like this:
 	 *
-	 * 		```
-	 * 		Copyright (C) 2018 Example Plugin Author
-	 * 		This file is distributed under the GPLv2.
-	 * 		```
+	 *      ```
+	 *      Copyright (C) 2018 Example Plugin Author
+	 *      This file is distributed under the GPLv2.
+	 *      ```
 	 *
 	 * [--package-name=<name>]
 	 * : Name to use for package name in the resulting POT file's `Project-Id-Version` header.
@@ -366,7 +366,8 @@ class MakePotCommand extends WP_CLI_Command {
 					$this->exceptions->mergeWith( $exception_translations );
 
 					return true;
-				} );
+				}
+			);
 
 			if ( ! empty( $exceptions ) ) {
 				WP_CLI::debug( sprintf( 'Ignoring any string already existing in: %s', implode( ',', $exceptions ) ), 'make-pot' );
@@ -426,7 +427,7 @@ class MakePotCommand extends WP_CLI_Command {
 
 		/** @var DirectoryIterator $file */
 		foreach ( $files as $file ) {
-			if ( $file->isFile() && $file->isReadable() && 'php' === $file->getExtension()) {
+			if ( $file->isFile() && $file->isReadable() && 'php' === $file->getExtension() ) {
 				$plugin_files[] = $file->getRealPath();
 			}
 		}
@@ -569,7 +570,7 @@ class MakePotCommand extends WP_CLI_Command {
 			WP_CLI::error( $e->getMessage() );
 		}
 
-		foreach( $this->exceptions as $translation ) {
+		foreach ( $this->exceptions as $translation ) {
 			if ( $translations->find( $translation ) ) {
 				unset( $translations[ $translation->getId() ] );
 			}
@@ -590,7 +591,7 @@ class MakePotCommand extends WP_CLI_Command {
 	 * @param Translations $translations Translations object.
 	 */
 	protected function audit_strings( $translations ) {
-		foreach( $translations as $translation ) {
+		foreach ( $translations as $translation ) {
 			/** @var Translation $translation */
 
 			$references = $translation->getReferences();
@@ -612,7 +613,7 @@ class MakePotCommand extends WP_CLI_Command {
 
 			// Check 2: Flag strings with different translator comments.
 			if ( $translation->hasExtractedComments() ) {
-				$comments = $translation->getExtractedComments();
+				$comments       = $translation->getExtractedComments();
 				$comments_count = count( $comments );
 
 				if ( $comments_count > 1 ) {
@@ -638,7 +639,7 @@ class MakePotCommand extends WP_CLI_Command {
 
 			// Check 4: Flag strings with multiple unordered placeholders (%s %s %s vs. %1$s %2$s %3$s).
 			$unordered_matches_count = preg_match_all( self::UNORDERED_SPRINTF_PLACEHOLDER_REGEX, $translation->getOriginal(), $unordered_matches );
-			$unordered_matches = $unordered_matches[0];
+			$unordered_matches       = $unordered_matches[0];
 
 			if ( $unordered_matches_count >= 2 ) {
 				WP_CLI::warning( sprintf(
@@ -781,7 +782,7 @@ class MakePotCommand extends WP_CLI_Command {
 	 */
 	private function get_wp_version() {
 		$version_php = $this->source . '/wp-includes/version.php';
-		if ( ! file_exists( $version_php) || ! is_readable( $version_php ) ) {
+		if ( ! file_exists( $version_php ) || ! is_readable( $version_php ) ) {
 			return false;
 		}
 
@@ -829,7 +830,7 @@ class MakePotCommand extends WP_CLI_Command {
 	 *
 	 * @return array Array of file headers in `HeaderKey => Header Value` format.
 	 */
-	public static function get_file_data_from_string( $string, $headers  ) {
+	public static function get_file_data_from_string( $string, $headers ) {
 		foreach ( $headers as $field => $regex ) {
 			if ( preg_match( '/^[ \t\/*#@]*' . preg_quote( $regex, '/' ) . ':(.*)$/mi', $string, $match ) && $match[1] ) {
 				$headers[ $field ] = static::_cleanup_header_comment( $match[1] );

--- a/src/MapCodeExtractor.php
+++ b/src/MapCodeExtractor.php
@@ -25,7 +25,7 @@ final class MapCodeExtractor extends JsCode {
 	 * {@inheritdoc}
 	 */
 	public static function fromString( $string, Translations $translations, array $options = [] ) {
-		if ( ! array_key_exists( 'file', $options ) || substr( $options['file'], -7 ) !==  '.js.map' ) {
+		if ( ! array_key_exists( 'file', $options ) || substr( $options['file'], -7 ) !== '.js.map' ) {
 			return;
 		}
 		$options['file'] = substr( $options['file'], 0, -7 ) . '.js';

--- a/src/PhpFunctionsScanner.php
+++ b/src/PhpFunctionsScanner.php
@@ -20,7 +20,8 @@ class PhpFunctionsScanner extends GettextPhpFunctionsScanner {
 				continue;
 			}
 
-			$context = $plural = null;
+			$context = null;
+			$plural  = null;
 
 			switch ( $functions[ $name ] ) {
 				case 'text_domain':

--- a/src/PotGenerator.php
+++ b/src/PotGenerator.php
@@ -24,7 +24,7 @@ class PotGenerator extends Po {
 	public static function setCommentBeforeHeaders( $comment ) {
 		$comments = explode( "\n", $comment );
 
-		foreach( $comments as $line ) {
+		foreach ( $comments as $line ) {
 			if ( '' !== trim( $line ) ) {
 				static::$comments_before_headers[] = '# ' . $line;
 			}


### PR DESCRIPTION
Simple, mostly whitespace related, fixes to make the code comply with the WPCliCS rules.

Fixes relate to the following rules:
* Align the equality operators in assignment blocks.
* No multiple assignments in one statement.
* Function declarations - including closures - should be multi-line, i.e. start on the line after the open brace and have the close brace on a line of its own.
* One space between a control structure keyword and the open parenthesis.
* No space between a function call/language construct keyword and the open parenthesis.
* The close brace of multi-line function calls should be on a line of its own.
* One space on the inside of open/close parenthesis when there is content between them.
* One space after comparison operators.
* Each array item in a multi-line array should be followed by a comma.
* When using array indexes, use no space on the inside of the square brackets when the index is a string or integer and use one space on the inside of the square brackets otherwise.
* No multiple blank lines in a row.
* Use tabs for indentation, spaces for inline alignment.

