### PR TITLE
PHPCS: fix up the code base [3] - no precision alignment

### DIFF
--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -76,9 +76,9 @@ class MakeJsonCommand extends WP_CLI_Command {
 		}
 
 		// Two is_dir() checks in case of a race condition.
-		if ( ! is_dir( $destination ) &&
-		     ! mkdir( $destination, 0777, true ) &&
-		     ! is_dir( $destination )
+		if ( ! is_dir( $destination )
+			&& ! mkdir( $destination, 0777, true )
+			&& ! is_dir( $destination )
 		) {
 			WP_CLI::error( 'Could not create destination directory!' );
 		}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -307,9 +307,9 @@ class MakePotCommand extends WP_CLI_Command {
 		WP_CLI::debug( sprintf( 'Destination: %s', $this->destination ), 'make-pot' );
 
 		// Two is_dir() checks in case of a race condition.
-		if ( ! is_dir( dirname( $this->destination ) ) &&
-		     ! mkdir( dirname( $this->destination ), 0777, true ) &&
-		     ! is_dir( dirname( $this->destination ) )
+		if ( ! is_dir( dirname( $this->destination ) )
+			&& ! mkdir( dirname( $this->destination ), 0777, true )
+			&& ! is_dir( dirname( $this->destination ) )
 		) {
 			WP_CLI::error( 'Could not create destination directory!' );
 		}


### PR DESCRIPTION
Fixes relate to the following rules:
* Precision alignment is strongly discouraged.

In these two cases, it made sense to also move the logical operators to the next line for improved readability.