### PR TITLE
PHPCS: fix up the code base [4] - multi-line function calls

### DIFF
--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -41,11 +41,12 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 		$this->code = str_replace( '/"/', '/\"/', $this->code );
 		$this->code = str_replace( '/"|\'/', '/\"|\\\'/', $this->code );
 
-		$ast = Peast::latest( $this->code, [
+		$peast_options = [
 			'sourceType' => Peast::SOURCE_TYPE_MODULE,
 			'comments'   => false !== $this->extractComments,
 			'jsx'        => true,
-		] )->parse();
+		];
+		$ast           = Peast::latest( $this->code, $peast_options )->parse();
 
 		$traverser = new Traverser();
 


### PR DESCRIPTION
Multi-line function calls need to have each argument on a new line.
In a next iteration of this principle, it is expected that a sniff will be introduced to ban multi-line function call arguments.

With this mind, a number of function calls with multi-line parameters which are currently already causing errors to be thrown by PHPCS, have been fixed by moving multi-line function call arguments out of the function call and defining these as a variable before passing it to the function call.
