### PR TITLE
Use extracted text domain when generating JSON files

### DIFF
--- a/features/makejson.feature
+++ b/features/makejson.feature
@@ -120,7 +120,47 @@ Feature: Split PO files into JSON files.
       "generator":"WP-CLI
       """
 
-  Scenario: Always uses messages as text domain
+  Scenario: Uses messages as the fallback text domain
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Foo Plugin"
+      """
+
+    When I run `wp i18n make-json foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE-56746e49c6485323d16a717754b7447e.json file should contain:
+      """
+      "domain":"messages"
+      """
+    And the foo-plugin/foo-plugin-de_DE-56746e49c6485323d16a717754b7447e.json file should contain:
+      """
+      "messages":{
+      """
+
+  Scenario: Uses the extraced text domain
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin-de_DE.po file:
       """
@@ -154,11 +194,11 @@ Feature: Split PO files into JSON files.
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE-56746e49c6485323d16a717754b7447e.json file should contain:
       """
-      "domain":"messages"
+      "domain":"foo-plugin"
       """
     And the foo-plugin/foo-plugin-de_DE-56746e49c6485323d16a717754b7447e.json file should contain:
       """
-      "messages":{
+      "foo-plugin":{
       """
 
   Scenario: Sets correct plural form

--- a/features/makejson.feature
+++ b/features/makejson.feature
@@ -508,7 +508,7 @@ Feature: Split PO files into JSON files.
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE-56746e49c6485323d16a717754b7447e.json file should contain:
       """
-      "domain":"messages"
+      "domain":"foo-plugin"
       """
     And the foo-plugin/foo-plugin-de_DE-56746e49c6485323d16a717754b7447e.json file should contain:
       """
@@ -549,11 +549,11 @@ Feature: Split PO files into JSON files.
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE-56746e49c6485323d16a717754b7447e.json file should contain:
       """
-          "domain": "messages",
+          "domain": "foo-plugin",
           "locale_data": {
-              "messages": {
+              "foo-plugin": {
                   "": {
-                      "domain": "messages",
+                      "domain": "foo-plugin",
                       "lang": "de_DE",
                       "plural-forms": "nplurals=2; plural=(n != 1);"
                   },

--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -153,8 +153,7 @@ class MakeJsonCommand extends WP_CLI_Command {
 			foreach ( $sources as $source ) {
 				if ( ! isset( $mapping[ $source ] ) ) {
 					$mapping[ $source ] = new Translations();
-					// See https://core.trac.wordpress.org/ticket/45441
-					//$mapping[ $source ]->setDomain( $translations->getDomain() );
+					$mapping[ $source ]->setDomain( $translations->getDomain() );
 					$mapping[ $source ]->setLanguage( $translations->getLanguage() );
 					$mapping[ $source ]->setHeader( 'PO-Revision-Date', $translations->getHeader( 'PO-Revision-Date' ) );
 


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/45441 got resolved for WordPress 5.0.3, which means we could default to the extracted domain again.