### PR TITLE
Fix #143: Use php SplFileInfo instead of Symfony

### DIFF
--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -6,7 +6,6 @@ use Gettext\Extractors\Po as PoExtractor;
 use Gettext\Generators\Po as PoGenerator;
 use Gettext\Translation;
 use Gettext\Translations;
-use Symfony\Component\Finder\SplFileInfo;
 use WP_CLI;
 use WP_CLI_Command;
 use WP_CLI\Utils;

--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -11,6 +11,7 @@ use WP_CLI_Command;
 use WP_CLI\Utils;
 use DirectoryIterator;
 use IteratorIterator;
+use SplFileInfo; 
 
 class MakeJsonCommand extends WP_CLI_Command {
 	/**


### PR DESCRIPTION
I don't know why the import was added, it was probably not intended by @swissspidy.

The correct class to use is PHP plain SplFileInfo. This will fix #143 