### PR TITLE
Fix: Warning: strpos(): Empty needle

### DIFF
--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -176,7 +176,7 @@ trait IterableCodeExtractor {
 			// Or the start of the matcher until the first wildcard matches the start of the path.
 			if (
 				( '' !== $root_relative_path && 0 === strpos( $base, $root_relative_path ) ) ||
-				0 === strpos( $root_relative_path, $base )
+				( '' !== $base && 0 === strpos( $root_relative_path, $base ) )
 			) {
 				return true;
 			}


### PR DESCRIPTION
Kept getting this warning when doing `--include="*.blade.php"`, among other things.

Related to #125 and #129