### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ vendor/
 *.txt
 *.log
 composer.lock
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "wp-cli/scaffold-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-i18n">
+	<description>Custom ruleset for WP-CLI I18n-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Ignoring select files/folders.
+		 https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+	<exclude-pattern>*/tests/data/*</exclude-pattern>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\I18n"/><!-- Namespaces. -->
+				<element value="wpcli_i18n"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -55,4 +55,24 @@
 		</properties>
 	</rule>
 
+	<!-- Whitelist method names for classes that extend a PSR-2 package. -->
+	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
+		<exclude-pattern>*/src/IterableCodeExtractor\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Whitelist variable names for classes that extend a PSR-2 package. -->
+	<rule ref="WordPress.NamingConventions.ValidVariableName">
+		<exclude-pattern>*/src/JsFunctionsScanner\.php$</exclude-pattern>
+		<exclude-pattern>*/src/PhpFunctionsScanner\.php$</exclude-pattern>
+		<exclude-pattern>*/src/MapCodeExtractor\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Allow for JavaScript format examples to be provided in comments.
+		 See: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizphpcommentedoutcode -->
+	<rule ref="Squiz.PHP.CommentedOutCode">
+		<properties>
+			<property name="maxPercentage" value="45"/>
+		</properties>
+	</rule>
+
 </ruleset>

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -111,7 +111,7 @@ trait IterableCodeExtractor {
 		$root_relative_path = str_replace( static::$dir, '', $file->getPathname() );
 
 		foreach ( $matchers as $path_or_file ) {
-			$pattern = preg_quote( str_replace( '*', '__wildcard__', $path_or_file ) );
+			$pattern = preg_quote( str_replace( '*', '__wildcard__', $path_or_file ), '/' );
 			$pattern = '(^|/)' . str_replace( '__wildcard__', '(.+)', $pattern );
 
 			// Base score is the amount of nested directories, discounting wildcards.

--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -153,8 +153,10 @@ class MakeJsonCommand extends WP_CLI_Command {
 			foreach ( $sources as $source ) {
 				if ( ! isset( $mapping[ $source ] ) ) {
 					$mapping[ $source ] = new Translations();
+
+					// phpcs:ignore Squiz.PHP.CommentedOutCode.Found -- Provide code that is meant to be used once the bug is fixed.
 					// See https://core.trac.wordpress.org/ticket/45441
-					//$mapping[ $source ]->setDomain( $translations->getDomain() );
+					// $mapping[ $source ]->setDomain( $translations->getDomain() );
 
 					$mapping[ $source ]->setHeader( 'Language', $translations->getLanguage() );
 					$mapping[ $source ]->setHeader( 'PO-Revision-Date', $translations->getHeader( 'PO-Revision-Date' ) );

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -897,7 +897,7 @@ class MakePotCommand extends WP_CLI_Command {
 	 *
 	 * @return string
 	 */
-	protected static function _cleanup_header_comment( $str ) {
+	protected static function _cleanup_header_comment( $str ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- Not changing because third-party commands might use/extend.
 		return trim( preg_replace( '/\s*(?:\*\/|\?>).*/', '', $str ) );
 	}
 }


### PR DESCRIPTION
### Composer: use wp-cli-tests ^2.1

... as that version contains the new WPCliCS PHPCS standard.

### .gitignore/.distignore: ignore phpcs/phpunit config files

* `.distignore`: no need to distribute the phpcs/phpunit config files.
* `.gitignore`: Allow devs to overwrite config files for PHPUnit and PHPCS
    - The `.dist` files should be committed. However, for their personal use, devs can overrule those files with versions without `.dist`.
        Those personal versions should never be committed.

As a side-note: for PHPCS, having a personal version while still using the original `.dist` file is made very easy, as you can just import the `.dist` file as a starting point, like so:
```xml
<?xml version="1.0"?>
<ruleset name="WP-CLI">
    <rule ref="./phpcs.xml.dist"/>
</ruleset>
```

### PHPCS: add a ruleset for this project

The file is completely documented in-line.

Fixes #158 

Related https://github.com/wp-cli/wp-cli/issues/5179