### PR TITLE
make pot command: Allow .jsx files.

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1638,6 +1638,48 @@ Feature: Generate a POT file of a WordPress project
       msgid "wrong-domain"
       """
 
+  Scenario: Parse .js and .jsx files for javascript translations
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       */
+      """
+    And a foo-plugin/foo-plugin.js file:
+      """
+      __( 'js', 'foo-plugin' );
+      """
+    And a foo-plugin/foo-plugin.jsx file:
+      """
+      __( 'jsx', 'foo-plugin' );
+      """
+    And a foo-plugin/foo-plugin.whatever file:
+      """
+      __( 'whatever', 'foo-plugin' );
+      """
+
+    When I try `wp i18n make-pot foo-plugin`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And the foo-plugin/foo-plugin.pot file should exist
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "js"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "jsx"
+      """
+    And the foo-plugin/foo-plugin.pot file should not contain:
+      """
+      msgid "whatever"
+      """
+
   Scenario: Extract translator comments from JavaScript file
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -575,7 +575,7 @@ class MakePotCommand extends WP_CLI_Command {
 					[
 						'include'    => $this->include,
 						'exclude'    => $this->exclude,
-						'extensions' => [ 'js' ],
+						'extensions' => [ 'js', 'jsx' ],
 					]
 				);
 


### PR DESCRIPTION
Currently, the js file scanner only scans for .js files.
In react projects, some developers name their react-files ending in .jsx
Since Gutenberg is using react, it won't hurt allowing those files to be parsed.