### PR TITLE
Workaround for parsing dynamic import.

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1638,6 +1638,34 @@ Feature: Generate a POT file of a WordPress project
       msgid "wrong-domain"
       """
 
+  Scenario: Ignores dynamic import in JavaScript file.
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       */
+      """
+    And a foo-plugin/foo-plugin.js file:
+      """
+      // This should not trigger a compiler error
+      import('./some-file.js').then(a => console.log(a))
+      __( '__', 'foo-plugin' );
+      """
+
+    When I run `wp i18n make-pot foo-plugin`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And the foo-plugin/foo-plugin.pot file should exist
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "__"
+      """
+
   Scenario: Extract translator comments from JavaScript file
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -38,15 +38,19 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 	 */
 	public function saveGettextFunctions( Translations $translations, array $options ) {
 		// Temporary workaround for https://github.com/wp-cli/i18n-command/issues/98.
-		$this->code = str_replace( '/"/', '/\"/', $this->code );
-		$this->code = str_replace( '/"|\'/', '/\"|\\\'/', $this->code );
+        $code = $this->code;
+		$code = str_replace( '/"/', '/\"/', $code );
+		$code = str_replace( '/"|\'/', '/\"|\\\'/', $code );
+		// Temporary workaround to fix dynamic imports. The τ is a greek letter.
+        // This will trick the parser into thinking that it is a normal method call.
+        $code = preg_replace( "/import(\\s*\\()/", "imporτ$1", $code );
 
 		$peast_options = [
 			'sourceType' => Peast::SOURCE_TYPE_MODULE,
 			'comments'   => false !== $this->extract_comments,
 			'jsx'        => true,
 		];
-		$ast           = Peast::latest( $this->code, $peast_options )->parse();
+		$ast           = Peast::latest( $code, $peast_options )->parse();
 
 		$traverser = new Traverser();
 

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -37,10 +37,8 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 	 * {@inheritdoc}
 	 */
 	public function saveGettextFunctions( Translations $translations, array $options ) {
-		// Temporary workaround for https://github.com/wp-cli/i18n-command/issues/98.
         $code = $this->code;
-		$code = str_replace( '/"/', '/\"/', $code );
-		$code = str_replace( '/"|\'/', '/\"|\\\'/', $code );
+        // See https://github.com/mck89/peast/issues/7
 		// Temporary workaround to fix dynamic imports. The τ is a greek letter.
         // This will trick the parser into thinking that it is a normal method call.
         $code = preg_replace( "/import(\\s*\\()/", "imporτ$1", $code );

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -37,11 +37,11 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 	 * {@inheritdoc}
 	 */
 	public function saveGettextFunctions( Translations $translations, array $options ) {
-        $code = $this->code;
-        // See https://github.com/mck89/peast/issues/7
+		$code = $this->code;
+		// See https://github.com/mck89/peast/issues/7
 		// Temporary workaround to fix dynamic imports. The τ is a greek letter.
-        // This will trick the parser into thinking that it is a normal method call.
-        $code = preg_replace( "/import(\\s*\\()/", "imporτ$1", $code );
+		// This will trick the parser into thinking that it is a normal method call.
+		$code = preg_replace( '/import(\\s*\\()/', 'imporτ$1', $code );
 
 		$peast_options = [
 			'sourceType' => Peast::SOURCE_TYPE_MODULE,


### PR DESCRIPTION
Peast does not support dynamic import syntax
https://github.com/mck89/peast/issues/7

This is a workaround for dynamic imports (to silently ignore them, they don't affect i18n generation).