### PR TITLE
Add test to cover translator comments with tab indentations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "gettext/gettext": "^4.6",
+        "gettext/gettext": "dev-master#68d9f76f709a12ad7c3159d0acb08f9cad159426",
         "mck89/peast": "^1.8",
         "wp-cli/wp-cli": "^2"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "wp-cli/scaffold-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^2.1"
+        "wp-cli/wp-cli-tests": "^2.1.3"
     },
     "config": {
         "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "gettext/gettext": "dev-master#68d9f76f709a12ad7c3159d0acb08f9cad159426",
+        "gettext/gettext": "^4.6.3",
         "mck89/peast": "^1.8",
         "wp-cli/wp-cli": "^2"
     },

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -527,7 +527,7 @@ Feature: Generate a POT file of a WordPress project
       /* translators: boo */ /* translators: this should get extracted too. */ /* some other comment */ $bar = g( __( 'bubu', 'foo-plugin' ) );
 
       {TAB}/*
-      {TAB} * translators: this comment block is intend with a tab and should get extracted too.
+      {TAB} * translators: this comment block is indented with a tab and should get extracted too.
       {TAB} */
       {TAB}__( 'yolo', 'foo-plugin' );
       """
@@ -577,7 +577,7 @@ Feature: Generate a POT file of a WordPress project
       """
     And the foo-plugin/foo-plugin.pot file should contain:
       """
-      #. translators: this comment block is intend with a tab and should get extracted too.
+      #. translators: this comment block is indented with a tab and should get extracted too.
       """
 
   Scenario: Generates a POT file for a child theme with no other files

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -494,6 +494,8 @@ Feature: Generate a POT file of a WordPress project
       """
 
   Scenario: Extract translator comments
+    Given I run `echo "\t"`
+    And save STDOUT as {TAB}
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:
       """
@@ -524,11 +526,10 @@ Feature: Generate a POT file of a WordPress project
 
       /* translators: boo */ /* translators: this should get extracted too. */ /* some other comment */ $bar = g( __( 'bubu', 'foo-plugin' ) );
 
-      	/*
-      	 * translators: this comment block is intend with a tab and should get extracted too.
-      	 */
-      __( 'yolo', 'foo-plugin' );
-
+      {TAB}/*
+      {TAB} * translators: this comment block is intend with a tab and should get extracted too.
+      {TAB} */
+      {TAB}__( 'yolo', 'foo-plugin' );
       """
 
     When I run `wp i18n make-pot foo-plugin`

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -520,9 +520,15 @@ Feature: Generate a POT file of a WordPress project
        */
        __( 'off', 'foo-plugin' );
 
-       /* translators: this should get extracted. */ $foo = __( 'baba', 'foo-plugin' );
+      /* translators: this should get extracted. */ $foo = __( 'baba', 'foo-plugin' );
 
-       /* translators: boo */ /* translators: this should get extracted too. */ /* some other comment */ $bar = g ( __( 'bubu', 'foo-plugin' ) );
+      /* translators: boo */ /* translators: this should get extracted too. */ /* some other comment */ $bar = g( __( 'bubu', 'foo-plugin' ) );
+
+      	/*
+      	 * translators: this comment block is intend with a tab and should get extracted too.
+      	 */
+      __( 'yolo', 'foo-plugin' );
+
       """
 
     When I run `wp i18n make-pot foo-plugin`
@@ -567,6 +573,10 @@ Feature: Generate a POT file of a WordPress project
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       #. translators: this should get extracted too.
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      #. translators: this comment block is intend with a tab and should get extracted too.
       """
 
   Scenario: Generates a POT file for a child theme with no other files


### PR DESCRIPTION
Fixes https://github.com/wp-cli/i18n-command/issues/169.

The test will pass with the fix from https://github.com/oscarotero/Gettext/pull/215.