### PR TITLE
Investigate include/exclude oddities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 wp-cli.local.yml
-node_modules/
-vendor/
+/node_modules
+/vendor
 *.zip
 *.tar.gz
 *.swp

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -159,6 +159,7 @@ trait IterableCodeExtractor {
 
 		/** @var string $root_relative_path */
 		$root_relative_path = str_replace( static::$dir, '', $dir->getPathname() );
+		$root_relative_path = ltrim( $root_relative_path, '/' );
 
 		foreach ( $matchers as $path_or_file ) {
 			// If the matcher contains no wildcards and the path matches the start of the matcher.

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -159,9 +159,10 @@ trait IterableCodeExtractor {
 
 		/** @var string $root_relative_path */
 		$root_relative_path = str_replace( static::$dir, '', $dir->getPathname() );
-		$root_relative_path = ltrim( $root_relative_path, '/' );
 
 		foreach ( $matchers as $path_or_file ) {
+			$path_or_file = ltrim( $path_or_file, '/' );
+
 			// If the matcher contains no wildcards and the path matches the start of the matcher.
 			if (
 				'' !== $root_relative_path &&
@@ -205,19 +206,18 @@ trait IterableCodeExtractor {
 				function ( $file, $key, $iterator ) use ( $include, $exclude, $extensions ) {
 					/** @var RecursiveCallbackFilterIterator $iterator */
 					/** @var SplFileInfo $file */
-
 					// If no $include is passed everything gets the weakest possible matching score.
 					$inclusion_score = empty( $include ) ? 0.1 : static::calculateMatchScore( $file, $include );
 					$exclusion_score = static::calculateMatchScore( $file, $exclude );
 
 					// Always include directories that aren't excluded.
-					if ( 0 === $exclusion_score && $iterator->hasChildren() ) {
+					if ( $file->isDir() && 0 === $exclusion_score ) {
 						return true;
 					}
 
-					if ( 0 === $inclusion_score || $exclusion_score > $inclusion_score ) {
+					if ( $file->isDir() && ( 0 === $inclusion_score || $exclusion_score > $inclusion_score ) ) {
 						// Always include directories that may have matching children even if they are excluded.
-						return $iterator->hasChildren() && static::containsMatchingChildren( $file, $include );
+						return static::containsMatchingChildren( $file, $include );
 					}
 
 					return ( $file->isFile() && in_array( $file->getExtension(), $extensions, true ) );

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -120,6 +120,7 @@ class IterableCodeExtractorTest extends PHPUnit_Framework_TestCase {
 			static::$base . 'foo/bar/foo/bar/foo/bar/deep_directory_also_included.php',
 			static::$base . 'foo/bar/foofoo/included.js',
 			static::$base . 'hoge/should_NOT_be_included.js',
+			static::$base . 'vendor/vendor-file.php',
 		);
 		$this->assertEquals( $expected, $result );
 	}

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -110,4 +110,28 @@ class IterableCodeExtractorTest extends PHPUnit_Framework_TestCase {
 		$expected = static::$base . 'foo/bar/excluded/ignored.js';
 		$this->assertContains( $expected, $result );
 	}
+
+	public function test_can_include_file_in_excluded_folder() {
+		$includes = [ 'vendor/vendor-file.php' ];
+		$excludes = [ 'vendor' ];
+		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
+		$expected = static::$base . 'vendor/vendor-file.php';
+		$this->assertContains( $expected, $result );
+	}
+
+	public function test_can_include_file_in_excluded_folder_with_leading_slash() {
+		$includes = [ '/vendor/vendor-file.php' ];
+		$excludes = [ 'vendor' ];
+		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
+		$expected = static::$base . 'vendor/vendor-file.php';
+		$this->assertContains( $expected, $result );
+	}
+
+	public function test_can_include_file_in_excluded_folder_by_wildcard() {
+		$includes = [ 'vendor/**' ];
+		$excludes = [ 'vendor' ];
+		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
+		$expected = static::$base . 'vendor/vendor-file.php';
+		$this->assertContains( $expected, $result );
+	}
 }


### PR DESCRIPTION
I've tried replicating #172 with the similar setup:

```
- test.php
- vendor/
- vendor/test.php
```

I ran:

```
vendor/bin/wp i18n make-pot /tmp/wp-i18n-test --debug --include=/vendor/test.php
```

And the `vendor/test.php` file was **not** included as expected.

Then I added 763941ad420d9448c51de738a9a40863d87cf362 and the file was now **included** as expected.

However, I failed at verifying this with a PHPUnit test.