### PR TITLE
Use correct argument name in warning message

### DIFF
--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -364,7 +364,7 @@ class MakePotCommand extends WP_CLI_Command {
 				$exceptions,
 				function ( $exception ) {
 					if ( ! file_exists( $exception ) ) {
-						WP_CLI::warning( sprintf( 'Invalid file provided to --except: %s', $exception ) );
+						WP_CLI::warning( sprintf( 'Invalid file provided to --subtract: %s', $exception ) );
 
 						return false;
 					}


### PR DESCRIPTION
This was renamed in https://github.com/wp-cli/i18n-command/commit/abf34a59c071ff23d08edc45e6b30228ae582bdf.