### PR TITLE
Add `--debug` output for the file being processed.

### DIFF
--- a/src/JsCodeExtractor.php
+++ b/src/JsCodeExtractor.php
@@ -28,6 +28,13 @@ final class JsCodeExtractor extends JsCode {
 		try {
 			$options += static::$options;
 
+			WP_CLI::debug(
+				sprintf(
+					'Parsing file %s',
+					$options['file']
+				)
+			);
+
 			$functions = new JsFunctionsScanner( $string );
 
 			$functions->enableCommentsExtraction( $options['extractComments'] );

--- a/src/JsCodeExtractor.php
+++ b/src/JsCodeExtractor.php
@@ -28,12 +28,7 @@ final class JsCodeExtractor extends JsCode {
 		try {
 			$options += static::$options;
 
-			WP_CLI::debug(
-				sprintf(
-					'Parsing file %s',
-					$options['file']
-				)
-			);
+			WP_CLI::debug( "Parsing file {$options['file']}" );
 
 			$functions = new JsFunctionsScanner( $string );
 

--- a/src/MapCodeExtractor.php
+++ b/src/MapCodeExtractor.php
@@ -39,14 +39,9 @@ final class MapCodeExtractor extends JsCode {
 				return;
 			}
 
-			WP_CLI::debug(
-				sprintf(
-					'Parsing file %s',
-					$options['file']
-				)
-			);
-
 			$string = implode( "\n", $map_object->sourcesContent );
+
+			WP_CLI::debug( "Parsing file {$options['file']}" );
 
 			$functions = new JsFunctionsScanner( $string );
 

--- a/src/MapCodeExtractor.php
+++ b/src/MapCodeExtractor.php
@@ -39,6 +39,13 @@ final class MapCodeExtractor extends JsCode {
 				return;
 			}
 
+			WP_CLI::debug(
+				sprintf(
+					'Parsing file %s',
+					$options['file']
+				)
+			);
+
 			$string = implode( "\n", $map_object->sourcesContent );
 
 			$functions = new JsFunctionsScanner( $string );

--- a/src/PhpCodeExtractor.php
+++ b/src/PhpCodeExtractor.php
@@ -46,12 +46,7 @@ final class PhpCodeExtractor extends PhpCode {
 	public static function fromString( $string, Translations $translations, array $options = [] ) {
 		$options += static::$options;
 
-		WP_CLI::debug(
-			sprintf(
-				'Parsing file %s',
-				$options['file']
-			)
-		);
+		WP_CLI::debug( "Parsing file {$options['file']}" );
 
 		$functions = new PhpFunctionsScanner( $string );
 

--- a/src/PhpCodeExtractor.php
+++ b/src/PhpCodeExtractor.php
@@ -46,6 +46,13 @@ final class PhpCodeExtractor extends PhpCode {
 	public static function fromString( $string, Translations $translations, array $options = [] ) {
 		$options += static::$options;
 
+		WP_CLI::debug(
+			sprintf(
+				'Parsing file %s',
+				$options['file']
+			)
+		);
+
 		$functions = new PhpFunctionsScanner( $string );
 
 		$functions->enableCommentsExtraction( $options['extractComments'] );


### PR DESCRIPTION
For debugging purposes it would be helpful to know what file is currently processed.

[Initially suggested](https://wordpress.slack.com/archives/C02RP4T41/p1571379966097800?thread_ts=1571300642.061700&cid=C02RP4T41) by @schlessera.