### PR TITLE
Add preliminary PHP 7.4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.2
+php: 7.3
 
 notifications:
   email:
@@ -51,6 +51,9 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.3
       env: WP_VERSION=latest
     - stage: test
@@ -73,4 +76,9 @@ jobs:
       env: WP_VERSION=trunk
     - stage: test
       php: 5.4
+      dist: precise
       env: WP_VERSION=5.1
+  allow_failures:
+    - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -743,7 +743,7 @@ class MakePotCommand extends WP_CLI_Command {
 			if ( isset( $this->main_file_data['License'] ) ) {
 				return sprintf(
 					"Copyright (C) %1\$s %2\$s\nThis file is distributed under the %3\$s.",
-					date( 'Y' ),
+					date( 'Y' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 					$this->main_file_data['Author'],
 					$this->main_file_data['License']
 				);
@@ -751,7 +751,7 @@ class MakePotCommand extends WP_CLI_Command {
 
 			return sprintf(
 				"Copyright (C) %1\$s %2\$s\nThis file is distributed under the same license as the %3\$s theme.",
-				date( 'Y' ),
+				date( 'Y' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 				$this->main_file_data['Author'],
 				$this->main_file_data['Theme Name']
 			);
@@ -761,7 +761,7 @@ class MakePotCommand extends WP_CLI_Command {
 			if ( isset( $this->main_file_data['License'] ) ) {
 				return sprintf(
 					"Copyright (C) %1\$s %2\$s\nThis file is distributed under the %3\$s.",
-					date( 'Y' ),
+					date( 'Y' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 					$this->main_file_data['Author'],
 					$this->main_file_data['License']
 				);
@@ -769,7 +769,7 @@ class MakePotCommand extends WP_CLI_Command {
 
 			return sprintf(
 				"Copyright (C) %1\$s %2\$s\nThis file is distributed under the same license as the %3\$s plugin.",
-				date( 'Y' ),
+				date( 'Y' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 				$this->main_file_data['Author'],
 				$this->main_file_data['Plugin Name']
 			);


### PR DESCRIPTION
The testing step for PHP 7.4 is still allowed to fail for now while we prepare the code base for the upcoming release.