### PR TITLE
Adapt code to gettext v4.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "gettext/gettext": "^4.6.3",
+        "gettext/gettext": "^4.8",
         "mck89/peast": "^1.8",
         "wp-cli/wp-cli": "^2"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -65,6 +65,7 @@
 		<properties>
 			<property name="customPropertiesWhitelist" type="array">
 				<element value="sourcesContent"/>
+				<element value="functionsScannerClass"/>
 			</property>
 		</properties>
 	</rule>
@@ -75,6 +76,11 @@
 		<properties>
 			<property name="maxPercentage" value="45"/>
 		</properties>
+	</rule>
+
+	<!-- Whitelist method names for classes that extend a PSR-2 package. -->
+	<rule ref="WordPress.DateTime.RestrictedFunctions.date_date">
+		<exclude-pattern>*/src/MakePotCommand\.php$</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -118,7 +118,7 @@ trait IterableCodeExtractor {
 			$base_score = count(
 				array_filter(
 					explode( '/', $path_or_file ),
-					function ( $component ) {
+					static function ( $component ) {
 						return '*' !== $component;
 					}
 				)
@@ -201,7 +201,7 @@ trait IterableCodeExtractor {
 		$files = new RecursiveIteratorIterator(
 			new RecursiveCallbackFilterIterator(
 				new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::UNIX_PATHS ),
-				function ( $file, $key, $iterator ) use ( $include, $exclude, $extensions ) {
+				static function ( $file, $key, $iterator ) use ( $include, $exclude, $extensions ) {
 					/** @var RecursiveCallbackFilterIterator $iterator */
 					/** @var SplFileInfo $file */
 

--- a/src/JsCodeExtractor.php
+++ b/src/JsCodeExtractor.php
@@ -5,7 +5,6 @@ namespace WP_CLI\I18n;
 use Exception;
 use Gettext\Extractors\JsCode;
 use Gettext\Translations;
-use Gettext\Utils\FunctionsScanner;
 use Peast\Syntax\Exception as PeastException;
 use WP_CLI;
 
@@ -23,18 +22,17 @@ final class JsCodeExtractor extends JsCode {
 		],
 	];
 
-    protected static $functionsScannerClass = 'WP_CLI\I18n\JsFunctionsScanner';
+	protected static $functionsScannerClass = 'WP_CLI\I18n\JsFunctionsScanner';
 
-    /**
-     * @inheritdoc
-     */
-    public static function fromString($string, Translations $translations, array $options = [])
-    {
-    	WP_CLI::debug( "Parsing file {$options['file']}" );
+	/**
+	 * @inheritdoc
+	 */
+	public static function fromString( $string, Translations $translations, array $options = [] ) {
+		WP_CLI::debug( "Parsing file {$options['file']}" );
 
-    	try {
-            static::fromStringMultiple($string, [$translations], $options);
-	    } catch ( PeastException $exception ) {
+		try {
+			static::fromStringMultiple( $string, [ $translations ], $options );
+		} catch ( PeastException $exception ) {
 			WP_CLI::debug(
 				sprintf(
 					'Could not parse file %1$s: %2$s (line %3$d, column %4$d)',
@@ -44,7 +42,7 @@ final class JsCodeExtractor extends JsCode {
 					$exception->getPosition()->getColumn()
 				)
 			);
-	    } catch ( Exception $exception ) {
+		} catch ( Exception $exception ) {
 			WP_CLI::debug(
 				sprintf(
 					'Could not parse file %1$s: %2$s',
@@ -52,8 +50,8 @@ final class JsCodeExtractor extends JsCode {
 					$exception->getMessage()
 				)
 			);
-	    }
-    }
+		}
+	}
 
 	/**
 	 * @inheritDoc

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -826,7 +826,7 @@ class MakePotCommand extends WP_CLI_Command {
 	 *
 	 * @return string|false Version number on success, false otherwise.
 	 */
-	private function get_wp_version() {
+	protected function get_wp_version() {
 		$version_php = $this->source . '/wp-includes/version.php';
 		if ( ! file_exists( $version_php ) || ! is_readable( $version_php ) ) {
 			return false;

--- a/src/PhpCodeExtractor.php
+++ b/src/PhpCodeExtractor.php
@@ -2,9 +2,9 @@
 
 namespace WP_CLI\I18n;
 
+use Exception;
 use Gettext\Extractors\PhpCode;
 use Gettext\Translations;
-use RecursiveIteratorIterator;
 use WP_CLI;
 
 final class PhpCodeExtractor extends PhpCode {
@@ -40,17 +40,25 @@ final class PhpCodeExtractor extends PhpCode {
 		],
 	];
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public static function fromString( $string, Translations $translations, array $options = [] ) {
-		$options += static::$options;
+    protected static $functionsScannerClass = 'WP_CLI\I18n\PhpFunctionsScanner';
 
-		WP_CLI::debug( "Parsing file {$options['file']}" );
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromString($string, Translations $translations, array $options = [])
+    {
+    	WP_CLI::debug( "Parsing file {$options['file']}" );
 
-		$functions = new PhpFunctionsScanner( $string );
-
-		$functions->enableCommentsExtraction( $options['extractComments'] );
-		$functions->saveGettextFunctions( $translations, $options );
-	}
+    	try {
+            static::fromStringMultiple($string, [$translations], $options);
+	    } catch ( Exception $exception ) {
+			WP_CLI::debug(
+				sprintf(
+					'Could not parse file %1$s: %2$s',
+					$options['file'],
+					$exception->getMessage()
+				)
+			);
+	    }
+    }
 }

--- a/src/PhpCodeExtractor.php
+++ b/src/PhpCodeExtractor.php
@@ -40,18 +40,17 @@ final class PhpCodeExtractor extends PhpCode {
 		],
 	];
 
-    protected static $functionsScannerClass = 'WP_CLI\I18n\PhpFunctionsScanner';
+	protected static $functionsScannerClass = 'WP_CLI\I18n\PhpFunctionsScanner';
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function fromString($string, Translations $translations, array $options = [])
-    {
-    	WP_CLI::debug( "Parsing file {$options['file']}" );
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function fromString( $string, Translations $translations, array $options = [] ) {
+		WP_CLI::debug( "Parsing file {$options['file']}" );
 
-    	try {
-            static::fromStringMultiple($string, [$translations], $options);
-	    } catch ( Exception $exception ) {
+		try {
+			static::fromStringMultiple( $string, [ $translations ], $options );
+		} catch ( Exception $exception ) {
 			WP_CLI::debug(
 				sprintf(
 					'Could not parse file %1$s: %2$s',
@@ -59,6 +58,6 @@ final class PhpCodeExtractor extends PhpCode {
 					$exception->getMessage()
 				)
 			);
-	    }
-    }
+		}
+	}
 }

--- a/src/PotGenerator.php
+++ b/src/PotGenerator.php
@@ -101,7 +101,7 @@ class PotGenerator extends PoGenerator {
 	 *
 	 * @return string[]
 	 */
-	private static function multilineQuote( $string ) {
+	protected static function multilineQuote( $string ) {
 		$lines = explode( "\n", $string );
 		$last  = count( $lines ) - 1;
 
@@ -123,7 +123,7 @@ class PotGenerator extends PoGenerator {
 	 * @param string $name   Name of the line, e.g. msgstr or msgid_plural.
 	 * @param string $value  The line to add.
 	 */
-	private static function addLines( array &$lines, $name, $value ) {
+	protected static function addLines( array &$lines, $name, $value ) {
 		$newlines = self::multilineQuote( $value );
 
 		if ( count( $newlines ) === 1 ) {


### PR DESCRIPTION
Bumps version of `gettext/gettext` to v4.8.0 and adapts the code to match the signature changes.