### PR TITLE
Fix specific license in a plugin

### DIFF
--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -488,6 +488,7 @@ class MakePotCommand extends WP_CLI_Command {
 					'Author',
 					'Author URI',
 					'Version',
+					'License',
 					'Domain Path',
 					'Text Domain',
 				];


### PR DESCRIPTION
The doc says: 
```
If a plugin or theme specifies a license in their main plugin file or stylesheet, the comment looks like
this: 
Copyright (C) 2018 Example Plugin Author
This file is distributed under the GPLv2.
```
but it dosen't seems to work for plugins. It looks like the "License" param in get_file_headers was missing.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
