### PR TITLE
Ensure that the pot file use the same license as the plugin

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -80,6 +80,34 @@ Feature: Generate a POT file of a WordPress project
       # This file is distributed under the same license as the Hello World plugin.
       """
 
+  Scenario: Use the same license as the plugin
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
+
+       __( 'Hello World', 'foo-plugin' );
+
+      """
+
+    When I run `wp i18n make-pot foo-plugin foo-plugin.pot`
+    Then the foo-plugin.pot file should contain:
+      """
+      # This file is distributed under the GPL-2.0+.
+      """
+
   Scenario: Sets Project-Id-Version
     When I run `wp scaffold plugin hello-world`
 

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -759,7 +759,7 @@ class MakePotCommand extends WP_CLI_Command {
 		}
 
 		if ( isset( $this->main_file_data['Plugin Name'] ) ) {
-			if ( isset( $this->main_file_data['License'] ) ) {
+			if ( isset( $this->main_file_data['License'] ) && ! empty( $this->main_file_data['License'] ) ) {
 				return sprintf(
 					"Copyright (C) %1\$s %2\$s\nThis file is distributed under the %3\$s.",
 					date( 'Y' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -488,6 +488,7 @@ class MakePotCommand extends WP_CLI_Command {
 					'Author',
 					'Author URI',
 					'Version',
+					'License',
 					'Domain Path',
 					'Text Domain',
 				];


### PR DESCRIPTION
It's green :)
![image](https://user-images.githubusercontent.com/176002/70705976-50f3fb00-1cd5-11ea-888a-3e98de9d24fc.png)
![image](https://user-images.githubusercontent.com/176002/70706261-de374f80-1cd5-11ea-9bcf-67cb31ffc34b.png)

This PR now includes a test case that ensure that the licensing information in the pot file is taken from the plugin file header if exists. Fixes #198.

