### PR TITLE
fix(make-pot): parses mangled webpack statements (closes #203)

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1592,6 +1592,7 @@ Feature: Generate a POT file of a WordPress project
       translate.__( 'translate.__', 'foo-plugin' );
 
       Object(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_7__["__"])( 'webpack.__', 'foo-plugin' );
+      Object(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_7__[/* __ */ "a"])( 'webpack.mangle.__', 'foo-plugin' );
 
       Object(u.__)( 'minified.__', 'foo-plugin' );
       Object(j._x)( 'minified._x', 'minified._x_context', 'foo-plugin' );
@@ -1659,6 +1660,10 @@ Feature: Generate a POT file of a WordPress project
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       msgid "webpack.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "webpack.mangle.__"
       """
     And the foo-plugin/foo-plugin.pot file should contain:
       """

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -231,8 +231,17 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 			// Matches unminified webpack statements:
 			// Object(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_7__["__"])( "translation" );
 			if ( 'Literal' === $property->getType() ) {
+				$name = $property->getValue();
+
+				// Matches mangled webpack statement:
+				// Object(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_7__[/* __ */ "a"])( "translation" );
+				$leading_property_comments = $property->getLeadingComments();
+				if ( count( $leading_property_comments ) === 1 && $leading_property_comments[0]->getKind() === 'multiline' ) {
+					$name = trim( $leading_property_comments[0]->getText() );
+				}
+
 				return [
-					'name'     => $property->getValue(),
+					'name'     => $name,
 					'comments' => $callee->getCallee()->getLeadingComments(),
 				];
 			}


### PR DESCRIPTION
When working with tree-shaking, vendor chunks and other optimizations webpack will create mangled function names for `__`, `_n`...

```js
Object(_utils__WEBPACK_IMPORTED_MODULE_6__[/* __*/ "a"])("Try again");
```

Reference: #203.