### PR TITLE
Add `wp i18n make-mo` command.

### DIFF
--- a/features/makemo.feature
+++ b/features/makemo.feature
@@ -79,7 +79,7 @@ Feature: Generate MO files from PO files
     And the return code should be 0
     And the result/foo-plugin-de_DE.mo file should exist
 
-  Scenario: Sets some meta data
+  Scenario: Does include headers
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin-de_DE.po file:
       """
@@ -113,13 +113,46 @@ Feature: Generate MO files from PO files
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE.mo file should contain:
       """
-      "translation-revision-date":
-      """
-    And the foo-plugin/foo-plugin-de.mo file should contain:
-      """
-      "generator":"WP-CLI
+      Language: de_DE
       """
     And the foo-plugin/foo-plugin-de_DE.mo file should contain:
       """
-      "source":"foo-plugin.js"
+      X-Domain: foo-plugin
+      """
+
+  Scenario: Does include translations
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Bar Plugin"
+      """
+
+    When I run `wp i18n make-mo foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.mo file should contain:
+      """
+      Bar Plugin
       """

--- a/features/makemo.feature
+++ b/features/makemo.feature
@@ -1,0 +1,125 @@
+Feature: Generate MO files from PO files
+
+  Background:
+    Given a WP install
+
+  Scenario: Bail for invalid source directories
+    When I try `wp i18n make-mo foo`
+    Then STDERR should contain:
+      """
+      Error: Source file or directory does not exist!
+      """
+    And the return code should be 1
+
+  Scenario: Uses source folder as destination by default
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Foo Plugin"
+      """
+
+    When I run `wp i18n make-mo foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.mo file should exist
+
+  Scenario: Allows setting custom destination directory
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Foo Plugin"
+      """
+
+    When I run `wp i18n make-mo foo-plugin result`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the result/foo-plugin-de_DE.mo file should exist
+
+  Scenario: Sets some meta data
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Foo Plugin"
+      """
+
+    When I run `wp i18n make-mo foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.mo file should contain:
+      """
+      "translation-revision-date":
+      """
+    And the foo-plugin/foo-plugin-de.mo file should contain:
+      """
+      "generator":"WP-CLI
+      """
+    And the foo-plugin/foo-plugin-de_DE.mo file should contain:
+      """
+      "source":"foo-plugin.js"
+      """

--- a/i18n-command.php
+++ b/i18n-command.php
@@ -17,3 +17,5 @@ if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {
 WP_CLI::add_command( 'i18n make-pot', '\WP_CLI\I18n\MakePotCommand' );
 
 WP_CLI::add_command( 'i18n make-json', '\WP_CLI\I18n\MakeJsonCommand' );
+
+WP_CLI::add_command( 'i18n make-mo', '\WP_CLI\I18n\MakeMoCommand' );

--- a/src/MakeMoCommand.php
+++ b/src/MakeMoCommand.php
@@ -38,9 +38,9 @@ class MakeMoCommand extends WP_CLI_Command {
 		}
 
 		// Two is_dir() checks in case of a race condition.
-		if ( ! is_dir( dirname( $destination ) )
-			&& ! mkdir( dirname( $destination ), 0777, true )
-			&& ! is_dir( dirname( $destination ) )
+		if ( ! is_dir( $destination )
+			&& ! mkdir( $destination, 0777, true )
+			&& ! is_dir( $destination )
 		) {
 			WP_CLI::error( 'Could not create destination directory!' );
 		}

--- a/src/MakeMoCommand.php
+++ b/src/MakeMoCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace WP_CLI\I18n;
+
+use DirectoryIterator;
+use Gettext\Translations;
+use IteratorIterator;
+use SplFileInfo;
+use WP_CLI;
+use WP_CLI\Utils;
+use WP_CLI_Command;
+
+class MakeMoCommand extends WP_CLI_Command {
+	/**
+	 * Create MO files from from PO files.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <source>
+	 * : Path to an existing PO file or a directory containing multiple PO files.
+	 *
+	 * [<destination>]
+	 * : Path to the destination directory for the resulting MO files. Defaults to the source directory.
+	 *
+	 * @when before_wp_load
+	 *
+	 * @throws WP_CLI\ExitException
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$source = realpath( $args[0] );
+		if ( ! $source || ( ! is_file( $source ) && ! is_dir( $source ) ) ) {
+			WP_CLI::error( 'Source file or directory does not exist!' );
+		}
+
+		$destination = is_file( $source ) ? dirname( $source ) : $source;
+		if ( isset( $args[1] ) ) {
+			$destination = $args[1];
+		}
+
+		// Two is_dir() checks in case of a race condition.
+		if ( ! is_dir( dirname( $destination ) )
+			&& ! mkdir( dirname( $destination ), 0777, true )
+			&& ! is_dir( dirname( $destination ) )
+		) {
+			WP_CLI::error( 'Could not create destination directory!' );
+		}
+
+		if ( is_file( $source ) ) {
+			$files = [ new SplFileInfo( $source ) ];
+		} else {
+			$files = new IteratorIterator( new DirectoryIterator( $source ) );
+		}
+
+		$result_count = 0;
+		/** @var DirectoryIterator $file */
+		foreach ( $files as $file ) {
+			if ( 'po' !== $file->getExtension() ) {
+				continue;
+			}
+
+			if ( ! $file->isFile() || ! $file->isReadable() ) {
+				WP_CLI::warning( sprintf( 'Could not read file %s', $file->getFilename() ) );
+				continue;
+			}
+
+			$file_basename    = basename( $file->getFilename(), '.po' );
+			$destination_file = "{$destination}/{$file_basename}.mo";
+
+			$translations = Translations::fromPoFile( $file->getPathname() );
+			if ( ! $translations->toMoFile( $destination_file ) ) {
+				WP_CLI::warning( sprintf( 'Could not create file %s', $destination_file ) );
+				continue;
+			}
+
+			$result_count++;
+		}
+
+		WP_CLI::success( sprintf( 'Created %d %s.', $result_count, Utils\pluralize( 'file', $result_count ) ) );
+	}
+}

--- a/src/MakeMoCommand.php
+++ b/src/MakeMoCommand.php
@@ -12,7 +12,7 @@ use WP_CLI_Command;
 
 class MakeMoCommand extends WP_CLI_Command {
 	/**
-	 * Create MO files from from PO files.
+	 * Create MO files from PO files.
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
This adds new i18n command `make-mo` to generate MO files from PO file(s). Examples:

```
// Reads from a single .po file
$ wp i18n make-mo ./wp-content/languages/slug.po
Success: Created 1 file.

// Reads from a directory—for multiple .po files.
$ wp i18n make-mo ./wp-content/languages/
Success: Created 5 files.
```

No unit tests added—relies on `Gettext\Translations::toMoFile()` that may cover the po-to-mo conversion tests.

Resolves #141.