### PR TITLE
Extract strings contained within eval()

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1616,7 +1616,7 @@ Feature: Generate a POT file of a WordPress project
       Object(u.__)( 'minified.__', 'foo-plugin' );
       Object(j._x)( 'minified._x', 'minified._x_context', 'foo-plugin' );
 
-      eval("__( 'Hello Eval World', 'foo-plugin' );" );
+      eval( "__( 'Hello Eval World', 'foo-plugin' );" );
       """
 
     When I run `wp i18n make-pot foo-plugin`

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1615,6 +1615,8 @@ Feature: Generate a POT file of a WordPress project
 
       Object(u.__)( 'minified.__', 'foo-plugin' );
       Object(j._x)( 'minified._x', 'minified._x_context', 'foo-plugin' );
+
+      eval("__( 'Hello Eval World', 'foo-plugin' );" );
       """
 
     When I run `wp i18n make-pot foo-plugin`
@@ -1695,6 +1697,10 @@ Feature: Generate a POT file of a WordPress project
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       msgctxt "minified._x_context"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Hello Eval World"
       """
     And the foo-plugin/foo-plugin.pot file should not contain:
       """

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -193,11 +193,25 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 					return;
 				}
 
+				$eval_contents = '';
+				/** @var Node\Node $argument */
+				foreach ( $node->getArguments() as $argument ) {
+					if ( 'Literal' === $argument->getType() ) {
+						/** @var Node\Literal $argument */
+						$eval_contents = $argument->getValue();
+						break;
+					}
+				}
+
+				if ( ! $eval_contents ) {
+					return;
+				}
+
 				// Override the line location to be that of the eval().
 				$options['line'] = $node->getLocation()->getStart()->getLine();
 
 				$class = get_class( $scanner );
-				$evals = new $class( $node->getArguments()[0]->getValue() );
+				$evals = new $class( $eval_contents );
 				$evals->enableCommentsExtraction( $options['extractComments'] );
 				$evals->saveGettextFunctions( $translations, $options );
 			}

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -196,10 +196,10 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 				// Override the line location to be that of the eval().
 				$options['line'] = $node->getLocation()->getStart()->getLine();
 
-				$class        = get_class( $scanner );
-				$eval_scaller = new $class( $node->getArguments()[0]->getValue() );
-				$eval_scaller->enableCommentsExtraction( $options['extractComments'] );
-				$eval_scaller->saveGettextFunctions( $translations, $options );
+				$class = get_class( $scanner );
+				$evals = new $class( $node->getArguments()[0]->getValue() );
+				$evals->enableCommentsExtraction( $options['extractComments'] );
+				$evals->saveGettextFunctions( $translations, $options );
 			}
 		);
 

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -146,8 +146,14 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 					return;
 				}
 
+				if ( isset( $options['line'] ) ) {
+					$line = $options['line'];
+				} else {
+					$line = $node->getLocation()->getStart()->getLine();
+				}
+
 				$translation = $translations->insert( $context, $original, $plural );
-				$translation->addReference( $file, $node->getLocation()->getStart()->getLine() );
+				$translation->addReference( $file, $line );
 
 				/** @var Node\Comment $comment */
 				foreach ( $all_comments as $comment ) {
@@ -186,6 +192,9 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 				if ( ! $callee || 'eval' != $callee['name'] ) {
 					return;
 				}
+
+				// Override the line location to be that of the eval().
+				$options['line'] = $node->getLocation()->getStart()->getLine();
 
 				$class        = get_class( $scanner );
 				$eval_scaller = new $class( $node->getArguments()[0]->getValue() );

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -189,7 +189,7 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 
 				$callee = $this->resolveExpressionCallee( $node );
 
-				if ( ! $callee || 'eval' != $callee['name'] ) {
+				if ( ! $callee || 'eval' !== $callee['name'] ) {
 					return;
 				}
 


### PR DESCRIPTION
Some build systems can result in the built files gettext functions being inside eval() calls.

One such example of this, is a webpack'd built file in this plugin: https://plugins.trac.wordpress.org/browser/mathml-block/trunk/dist/mathml-block.js?rev=2276811#L245

Currently, the relevant output is this:
```
#: src/mathml-block.js:35
msgid "MathML formula:"
msgstr ""

#: src/mathml-inline.js:10
msgid "MathML"
msgstr ""
```

which doesn't work for WordPress Translation files, as those src files are never enqueued, only the built files.
After the change, here's the output:
```
#: dist/mathml-block.js:245
#: src/mathml-block.js:35
msgid "MathML formula:"
msgstr ""

#: dist/mathml-block.js:257
#: src/mathml-inline.js:10
msgid "MathML"
msgstr ""
```