### PR TITLE
Add support to IterableCodeExtractor for symlinks.

### DIFF
--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -209,7 +209,7 @@ trait IterableCodeExtractor {
 
 		$files = new RecursiveIteratorIterator(
 			new RecursiveCallbackFilterIterator(
-				new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::UNIX_PATHS ),
+				new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::UNIX_PATHS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS ),
 				static function ( $file, $key, $iterator ) use ( $include, $exclude, $extensions ) {
 					/** @var RecursiveCallbackFilterIterator $iterator */
 					/** @var SplFileInfo $file */

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -2,11 +2,11 @@
 
 namespace WP_CLI\I18n\Tests;
 
-use PHPUnit_Framework_TestCase;
 use WP_CLI\I18n\IterableCodeExtractor;
+use WP_CLI\Tests\TestCase;
 use WP_CLI\Utils;
 
-class IterableCodeExtractorTest extends PHPUnit_Framework_TestCase {
+class IterableCodeExtractorTest extends TestCase {
 
 	/** @var string A path files are located */
 	private static $base;
@@ -21,6 +21,12 @@ class IterableCodeExtractorTest extends PHPUnit_Framework_TestCase {
 		$property->setAccessible( true );
 		$property->setValue( null, self::$base );
 		$property->setAccessible( false );
+	}
+
+	public function tearDown() {
+		if ( file_exists( self::$base . '/symlinked' ) ) {
+			unlink( self::$base . '/symlinked' );
+		}
 	}
 
 	public function test_can_include_files() {
@@ -175,5 +181,13 @@ class IterableCodeExtractorTest extends PHPUnit_Framework_TestCase {
 		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
 		$expected = array();
 		$this->assertEquals( $expected, $result );
+	}
+
+	public function test_can_include_file_in_symlinked_folder() {
+		symlink( self::$base . '/baz', self::$base . '/symlinked' );
+		$includes = [ 'symlinked/includes/should_be_included.js' ];
+		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, [], [ 'php', 'js' ] );
+		$expected = static::$base . 'symlinked/includes/should_be_included.js';
+		$this->assertContains( $expected, $result );
 	}
 }


### PR DESCRIPTION
Could only get the tests to pass locally with the [yoast polyfill TestCase](https://github.com/Yoast/PHPUnit-Polyfills#option-1-yoastphpunitpolyfillstestcasestestcase) but let me know if you want me to revert to `PHPUnit_Framework_TestCase`