### PR TITLE
Fix string extraction from block.json

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2746,6 +2746,119 @@ Feature: Generate a POT file of a WordPress project
       msgid "message"
       """
 
+  Scenario: Extract strings from all block.json files when domain is ignored
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       */
+      """
+    And a foo-plugin/block_one/block.json file:
+      """
+      {
+        "name": "my-plugin/notice",
+        "title": "Notice",
+        "category": "common",
+        "parent": [ "core/group" ],
+        "icon": "star",
+        "description": "Shows warning, error or success notices  ...",
+        "keywords": [ "alert", "message" ],
+        "textdomain": "my-plugin",
+        "attributes": {
+          "message": {
+            "type": "string",
+            "source": "html",
+            "selector": ".message"
+          }
+        },
+        "styles": [
+          { "name": "default", "label": "Default", "isDefault": true },
+          { "name": "other", "label": "Other" }
+        ],
+        "editorScript": "build/editor.js",
+        "script": "build/main.js",
+        "editorStyle": "build/editor.css",
+        "style": "build/style.css"
+      }
+      """
+    And a foo-plugin/block_two/block.json file:
+      """
+      {
+        "name": "my-plugin/block_two",
+        "title": "Second Notice",
+        "category": "common",
+        "parent": [ "core/group" ],
+        "icon": "star",
+        "description": "Another way to show warning, error or success notices  ...",
+        "keywords": [ "alert", "message" ],
+        "attributes": {
+          "message": {
+            "type": "string",
+            "source": "html",
+            "selector": ".message"
+          }
+        },
+        "styles": [
+          { "name": "default", "label": "Default", "isDefault": true },
+          { "name": "other", "label": "Other" }
+        ],
+        "editorScript": "build/editor.js",
+        "script": "build/main.js",
+        "editorStyle": "build/editor.css",
+        "style": "build/style.css"
+      }
+      """
+
+    When I try `wp i18n make-pot foo-plugin --ignore-domain`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And the foo-plugin/foo-plugin.pot file should exist
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Foo Plugin"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgctxt "block title"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Notice"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgctxt "block description"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Shows warning, error or success notices  ..."
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgctxt "block keyword"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "alert"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "message"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Second Notice"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Another way to show warning, error or success notices  ..."
+      """
+
   Scenario: Skips block.json file altogether
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:

--- a/src/BlockExtractor.php
+++ b/src/BlockExtractor.php
@@ -34,8 +34,8 @@ final class BlockExtractor extends Extractor implements ExtractorInterface {
 
 		$domain = isset( $file_data['textdomain'] ) ? $file_data['textdomain'] : null;
 
-		// Allow missing domain, but skip if they don't match.
-		if ( null !== $domain && $domain !== $translations->getDomain() ) {
+		// Always allow missing domain or when --ignore-domain is used, but skip if domains don't match.
+		if ( null !== $translations->getDomain() && null !== $domain && $domain !== $translations->getDomain() ) {
 			return;
 		}
 


### PR DESCRIPTION
The current logic in BlockExtractor stops processing the block.json file when `--ignore-domain` is present, but the json file contains non-empty `"textdomain"` property. This PR adjusts the check to make sure that the strings are always extracted when `--ignore-domain` is set, regardless of the `textdomain` presence or value. The possible flows can be summarized as:
1. `--ignore-domain` is set - always extract the strings.
2. `--domain=<value>` is present and block.json has no `textdomain` or has `"textdomain":null`- extract the strings.
3. `--domain=<value>` is present and block.json has matching `textdomain` value - extract the strings.
4. `--domain=<value>` is present and block.json has no matching `textdomain` value - ignore the file.

Fixes https://github.com/wp-cli/i18n-command/issues/252
