### PR TITLE
Remove now unneeded workaround in JS scanner

### DIFF
--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -43,18 +43,12 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 			$translations = $translations[0];
 		}
 
-		$code = $this->code;
-		// See https://github.com/mck89/peast/issues/7
-		// Temporary workaround to fix dynamic imports. The τ is a greek letter.
-		// This will trick the parser into thinking that it is a normal method call.
-		$code = preg_replace( '/import(\\s*\\()/', 'imporτ$1', $code );
-
 		$peast_options = [
 			'sourceType' => Peast::SOURCE_TYPE_MODULE,
 			'comments'   => false !== $this->extract_comments,
 			'jsx'        => true,
 		];
-		$ast           = Peast::latest( $code, $peast_options )->parse();
+		$ast           = Peast::latest( $this->code, $peast_options )->parse();
 
 		$traverser = new Traverser();
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

This partially reverts #164 as the upstream issue has been fixed a while ago. So this workaround should no longer be necessary.