### PR TITLE
Fix string extraction when using template literals

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1969,6 +1969,47 @@ Feature: Generate a POT file of a WordPress project
       msgid "Hello JSX"
       """
 
+  Scenario: Extract strings in template literals in JavaScript file
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       */
+      """
+    And a foo-plugin/foo-plugin.js file:
+      """
+      /* translators: %s viewport width as css, ie: 100% */
+      __( `Import me (%spx)`, 'foo-plugin' );
+
+      /* translators: %s viewport width as css, ie: 100% */
+      __( `Do not ${x} import me (%spx)`, 'foo-plugin' );
+      """
+    When I try `wp i18n make-pot foo-plugin`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And the foo-plugin/foo-plugin.pot file should exist
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Foo Plugin"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "Import me (%spx)"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      #. translators: %s viewport width as css, ie: 100%
+      """
+    And the foo-plugin/foo-plugin.pot file should not contain:
+      """
+      msgid "Do not ${x} import me (%spx)"
+      """
+
   Scenario: Extract translator comments from JavaScript map file
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -117,6 +117,15 @@ final class JsFunctionsScanner extends GettextJsFunctionsScanner {
 						/** @var Node\Literal $argument */
 						$args[] = $argument->getValue();
 					}
+
+					if ( 'TemplateLiteral' === $argument->getType() && 0 === count( $argument->getExpressions() ) ) {
+						/** @var Node\TemplateLiteral $argument */
+						/** @var Node\TemplateElement[] $parts */
+
+						// Since there are no expressions within the TemplateLiteral, there is only one TemplateElement.
+						$parts  = $argument->getParts();
+						$args[] = $parts[0]->getValue();
+					}
 				}
 
 				switch ( $functions[ $callee['name'] ] ) {


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Fixes #257