### PR TITLE
Add `ext-mbstring` to list of suggested dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "ext-mbstring": "*",
         "gettext/gettext": "^4.8",
         "mck89/peast": "^1.8",
         "wp-cli/wp-cli": "^2.5"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wp-cli/wp-cli-tests": "^3.0.11"
     },
     "suggest": {
-        "ext-mbstring": "Used for calculation include/exclude matches in code extraction"
+        "ext-mbstring": "Used for calculating include/exclude matches in code extraction"
     },
     "config": {
         "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         }
     ],
     "require": {
-        "ext-mbstring": "*",
         "gettext/gettext": "^4.8",
         "mck89/peast": "^1.8",
         "wp-cli/wp-cli": "^2.5"
@@ -19,6 +18,9 @@
     "require-dev": {
         "wp-cli/scaffold-command": "^1.2 || ^2",
         "wp-cli/wp-cli-tests": "^3.0.11"
+    },
+    "suggest": {
+        "ext-mbstring": "Used for calculation include/exclude matches in code extraction"
     },
     "config": {
         "process-timeout": 7200,

--- a/i18n-command.php
+++ b/i18n-command.php
@@ -14,7 +14,17 @@ if ( class_exists( 'WP_CLI\Dispatcher\CommandNamespace' ) ) {
 	WP_CLI::add_command( 'i18n', '\WP_CLI\I18n\CommandNamespace' );
 }
 
-WP_CLI::add_command( 'i18n make-pot', '\WP_CLI\I18n\MakePotCommand' );
+WP_CLI::add_command(
+	'i18n make-pot',
+	'\WP_CLI\I18n\MakePotCommand',
+	array(
+		'before_invoke' => static function() {
+			if ( ! function_exists( 'mb_ereg' ) ) {
+				WP_CLI::error( 'The mbstring extension is required for string extraction to work reliably.' );
+			}
+		},
+	)
+);
 
 WP_CLI::add_command( 'i18n make-json', '\WP_CLI\I18n\MakeJsonCommand' );
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

`IterableCodeExtractor` uses `mb_ereg`.

Fixes #138
