### PR TITLE
make-pot: add `subtract-and-merge` flag

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2700,6 +2700,7 @@ Feature: Generate a POT file of a WordPress project
       """
       msgid "Some other text"
       """
+
   @less-than-php-7.3
   Scenario: Add references to files used in exception list
     Given an empty directory
@@ -2792,15 +2793,15 @@ Feature: Generate a POT file of a WordPress project
       """
     And the exception.pot file should contain:
       """
-      #: foo-plugin:17
+      #: foo-plugin.php:17
       """
     And the exception.pot file should contain:
       """
-      #: foo-plugin:19
+      #: foo-plugin.php:19
       """
     And the exception.pot file should contain:
       """
-      #: foo-plugin:23
+      #: foo-plugin.php:23
       """
 
   Scenario: Extract strings for a generic project

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2700,6 +2700,108 @@ Feature: Generate a POT file of a WordPress project
       """
       msgid "Some other text"
       """
+  @less-than-php-7.3
+  Scenario: Add references to files used in exception list
+    Given an empty directory
+    And a exception.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #: bar-plugin.php:2
+      #: bar-baz-plugin.php:20
+      msgid "Foo Bar"
+      msgstr ""
+
+      #: bar-plugin.php:5
+      #: bar-bar.php:50
+      msgid "Bar Baz"
+      msgstr ""
+
+      #: bar-plugin.php:17
+      #: bar-baz-plugin.php:99
+      #: foobar/plugin.php:39
+      msgid "Some other text"
+      msgstr ""
+      """
+    And a foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Plugin URI:  https://example.com
+       * Description:
+       * Version:     0.1.0
+       * Author:
+       * Author URI:
+       * License:     GPL-2.0+
+       * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
+       * Text Domain: foo-plugin
+       * Domain Path: /languages
+       */
+
+       __( 'Hello World', 'foo-plugin' );
+
+       __( 'Foo Bar', 'foo-plugin' );
+
+       __( 'Bar Baz', 'foo-plugin' );
+
+       __( 'Some text', 'foo-plugin' );
+
+       __( 'Some other text', 'foo-plugin' );
+      """
+
+    When I run `wp i18n make-pot . foo-plugin.pot --domain=foo-plugin --subtract=exception.pot --subtract-and-merge`
+    Then STDOUT should be:
+      """
+      Plugin file detected.
+      Success: POT file successfully generated!
+      """
+    And STDERR should be empty
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "Hello World"
+      """
+    And the foo-plugin.pot file should contain:
+      """
+      msgid "Some text"
+      """
+    And the foo-plugin.pot file should not contain:
+      """
+      msgid "Foo Bar"
+      """
+    And the foo-plugin.pot file should not contain:
+      """
+      msgid "Bar Baz"
+      """
+    And the foo-plugin.pot file should not contain:
+      """
+      msgid "Some other text"
+      """
+    And the exception.pot file should contain:
+      """
+      #: foo-plugin:17
+      """
+    And the exception.pot file should contain:
+      """
+      #: foo-plugin:19
+      """
+    And the exception.pot file should contain:
+      """
+      #: foo-plugin:23
+      """
 
   Scenario: Extract strings for a generic project
     Given an empty example-project directory

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -674,9 +674,7 @@ class MakePotCommand extends WP_CLI_Command {
 
 				if ( $this->subtract_and_merge ) {
 					$translation = $translations[ $exception_translation->getId() ];
-					foreach ( $translation->getReferences() as $reference ) {
-						$exception_translation->addReference( $reference[0], $reference[1] );
-					}
+					$exception_translation->mergeWith( $translation );
 				}
 
 				unset( $translations[ $exception_translation->getId() ] );

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -196,7 +196,7 @@ class MakePotCommand extends WP_CLI_Command {
 	 * different content and no duplicate strings between them.
 	 *
 	 * [--subtract-and-merge]
-	 * : Whether source code references from the generated POT file should be instead added to the POT file
+	 * : Whether source code references and comments from the generated POT file should be instead added to the POT file
 	 * used for subtraction. Warning: this modifies the files passed to `--subtract`!
 	 *
 	 * [--include=<paths>]

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -30,9 +30,14 @@ class MakePotCommand extends WP_CLI_Command {
 	protected $merge = [];
 
 	/**
-	 * @var Translations
+	 * @var Translations[]
 	 */
-	protected $exceptions;
+	protected $exceptions = [];
+
+	/**
+	 * @var bool
+	 */
+	protected $subtract_and_merge;
 
 	/**
 	 * @var array
@@ -189,6 +194,10 @@ class MakePotCommand extends WP_CLI_Command {
 	 * Any string which is found on that denylist will not be extracted.
 	 * This can be useful when you want to create multiple POT files from the same source directory with slightly
 	 * different content and no duplicate strings between them.
+	 *
+	 * [--subtract-and-merge]
+	 * : Whether source code references from the generated POT file should be instead added to the POT file
+	 * used for subtraction. Warning: this modifies the files passed to `--subtract`!
 	 *
 	 * [--include=<paths>]
 	 * : Comma-separated list of files and paths that should be used for string extraction.
@@ -393,31 +402,21 @@ class MakePotCommand extends WP_CLI_Command {
 			}
 		}
 
-		$this->exceptions = new Translations();
-
 		if ( isset( $assoc_args['subtract'] ) ) {
-			$exceptions = explode( ',', $assoc_args['subtract'] );
+			$this->subtract_and_merge = Utils\get_flag_value( $assoc_args, 'subtract-and-merge', false );
 
-			$exceptions = array_filter(
-				$exceptions,
-				function ( $exception ) {
-					if ( ! file_exists( $exception ) ) {
-						WP_CLI::warning( sprintf( 'Invalid file provided to --subtract: %s', $exception ) );
+			$files = explode( ',', $assoc_args['subtract'] );
 
-						return false;
-					}
-
-					$exception_translations = new Translations();
-
-					Po::fromFile( $exception, $exception_translations );
-					$this->exceptions->mergeWith( $exception_translations );
-
-					return true;
+			foreach ( $files as $file ) {
+				if ( ! file_exists( $file ) ) {
+					WP_CLI::warning( sprintf( 'Invalid file provided to --subtract: %s', $file ) );
+					continue;
 				}
-			);
 
-			if ( ! empty( $exceptions ) ) {
-				WP_CLI::debug( sprintf( 'Ignoring any string already existing in: %s', implode( ',', $exceptions ) ), 'make-pot' );
+				WP_CLI::debug( sprintf( 'Ignoring any string already existing in: %s', $file ), 'make-pot' );
+
+				$this->exceptions[ $file ] = new Translations();
+				Po::fromFile( $file, $this->exceptions[ $file ] );
 			}
 		}
 
@@ -666,9 +665,25 @@ class MakePotCommand extends WP_CLI_Command {
 			WP_CLI::error( $e->getMessage() );
 		}
 
-		foreach ( $this->exceptions as $translation ) {
-			if ( $translations->find( $translation ) ) {
-				unset( $translations[ $translation->getId() ] );
+		foreach ( $this->exceptions as $file => $exception_translations ) {
+			/** @var Translation $exception_translation */
+			foreach ( $exception_translations as $exception_translation ) {
+				if ( ! $translations->find( $exception_translation ) ) {
+					continue;
+				}
+
+				if ( $this->subtract_and_merge ) {
+					$translation = $translations[ $exception_translation->getId() ];
+					foreach ( $translation->getReferences() as $reference ) {
+						$exception_translation->addReference( $reference[0], $reference[1] );
+					}
+				}
+
+				unset( $translations[ $exception_translation->getId() ] );
+			}
+
+			if ( $this->subtract_and_merge ) {
+				PotGenerator::toFile( $exception_translations, $file );
 			}
 		}
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

This PR adds a new `--subtract-and-merge` flag to the `make-pot` command, which can be used in combination with `--subtract`. When used, source code references from the generated POT file will instead be added to the POT file(s) passed to `--subtract`

Example:

```bash
# In foo-plugin/
wp i18n make-pot . foo-plugin.pot --subtract=exceptions.pot

# foo-plugin.pot will not contain any of the strings that are also in exceptions.pot
# exceptions.pot will now however contain all source code references for these strings
```

While I suggested adding dedicated commands for this feature a few years ago, in hindsight thats seems a bit overkill. It's quite the advanced configuration option that's probably only ever used for WordPress core, so just adding a flag feels like the better choice here.

Fixes #105
