### PR TITLE
Fix tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
 		 beStrictAboutTodoAnnotatedTests="true"
 		 colors="true"
 		 verbose="true">
-	<testsuite>
+	<testsuite name="wp-cli/i18n-command tests">
 		<directory suffix="Test.php">tests</directory>
 	</testsuite>
 

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -6,6 +6,7 @@ use Gettext\Extractors\Po;
 use Gettext\Merge;
 use Gettext\Translation;
 use Gettext\Translations;
+use Gettext\Utils\ParsedComment;
 use WP_CLI;
 use WP_CLI_Command;
 use WP_CLI\Utils;
@@ -677,10 +678,10 @@ class MakePotCommand extends WP_CLI_Command {
 				$comments = array_filter(
 					$comments,
 					function ( $comment ) {
-						/** @var string $comment */
+						/** @var ParsedComment|string $comment */
 						/** @var string $file_header */
 						foreach ( $this->get_file_headers( $this->project_type ) as $file_header ) {
-							if ( 0 === strpos( $comment, $file_header ) ) {
+							if ( 0 === strpos( ( $comment instanceof ParsedComment ? $comment->getComment() : $comment ), $file_header ) ) {
 								return null;
 							}
 						}

--- a/src/PotGenerator.php
+++ b/src/PotGenerator.php
@@ -4,6 +4,7 @@ namespace WP_CLI\I18n;
 
 use Gettext\Generators\Po as PoGenerator;
 use Gettext\Translations;
+use Gettext\Utils\ParsedComment;
 
 /**
  * POT file generator.
@@ -57,8 +58,9 @@ class PotGenerator extends PoGenerator {
 			}
 
 			if ( $translation->hasExtractedComments() ) {
+				/** @var ParsedComment|string $comment */
 				foreach ( $translation->getExtractedComments() as $comment ) {
-					$lines[] = '#. ' . $comment;
+					$lines[] = '#. ' . ( $comment instanceof ParsedComment ? $comment->getComment() : $comment );
 				}
 			}
 

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -11,7 +11,9 @@ class IterableCodeExtractorTest extends TestCase {
 	/** @var string A path files are located */
 	private static $base;
 
-	public function setUp() {
+	public function set_up() {
+		parent::set_up();
+
 		/**
 		 * PHP5.4 cannot set property with __DIR__ constant.
 		 */
@@ -23,10 +25,12 @@ class IterableCodeExtractorTest extends TestCase {
 		$property->setAccessible( false );
 	}
 
-	public function tearDown() {
+	public function tear_down() {
 		if ( file_exists( self::$base . '/symlinked' ) ) {
 			unlink( self::$base . '/symlinked' );
 		}
+
+		parent::tear_down();
 	}
 
 	public function test_can_include_files() {

--- a/tests/PotGeneratorTest.php
+++ b/tests/PotGeneratorTest.php
@@ -17,9 +17,9 @@ class PotGeneratorTest extends TestCase {
 
 		$result = PotGenerator::toString( $translations );
 
-		$this->assertContains( 'msgid "%d cat"', $result );
-		$this->assertContains( 'msgid_plural "%d cats"', $result );
-		$this->assertContains( 'msgstr[0] ""', $result );
-		$this->assertContains( 'msgstr[1] ""', $result );
+		$this->assertStringContainsString( 'msgid "%d cat"', $result );
+		$this->assertStringContainsString( 'msgid_plural "%d cats"', $result );
+		$this->assertStringContainsString( 'msgstr[0] ""', $result );
+		$this->assertStringContainsString( 'msgstr[1] ""', $result );
 	}
 }

--- a/tests/PotGeneratorTest.php
+++ b/tests/PotGeneratorTest.php
@@ -5,9 +5,9 @@ namespace WP_CLI\I18n\Tests;
 use Gettext\Translation;
 use WP_CLI\I18n\PotGenerator;
 use Gettext\Translations;
-use PHPUnit_Framework_TestCase;
+use WP_CLI\Tests\TestCase;
 
-class PotGeneratorTest extends PHPUnit_Framework_TestCase {
+class PotGeneratorTest extends TestCase {
 	public function test_adds_correct_amount_of_plural_strings() {
 		$translations = new Translations();
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Fixes  PHPUnit tests so that they can be run locally without issues

Also fixes PotGenerator to check for `ParsedComment` instances as these can now be returned since v4.8.5 (https://github.com/php-gettext/Gettext/pull/271)

See https://github.com/wp-cli/i18n-command/runs/3065527614#step:12:627 for how tests are currently failing