### PR TITLE
fix: Dependency gettext 4.8.5 mixes objects and strings (resolves #269)

### DIFF
--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -680,6 +680,9 @@ class MakePotCommand extends WP_CLI_Command {
 						/** @var string $comment */
 						/** @var string $file_header */
 						foreach ( $this->get_file_headers( $this->project_type ) as $file_header ) {
+							if ( is_object( $comment ) && method_exists( $comment, 'getComment' ) ) {
+								$comment = $comment->getComment();
+							}
 							if ( 0 === strpos( $comment, $file_header ) ) {
 								return null;
 							}

--- a/src/PotGenerator.php
+++ b/src/PotGenerator.php
@@ -58,6 +58,9 @@ class PotGenerator extends PoGenerator {
 
 			if ( $translation->hasExtractedComments() ) {
 				foreach ( $translation->getExtractedComments() as $comment ) {
+					if ( is_object( $comment ) && method_exists( $comment, 'getComment' ) ) {
+						$comment = $comment->getComment();
+					}
 					$lines[] = '#. ' . $comment;
 				}
 			}


### PR DESCRIPTION
In gettext v4.8.5 it is now possible for the `$comment` variable to be an object here instead of just a string.