### PR TITLE
Add new field to translate in `theme.json`

### DIFF
--- a/assets/theme-i18n.json
+++ b/assets/theme-i18n.json
@@ -3,7 +3,8 @@
 		"typography": {
 				"fontSizes": [
 					{
-						"name": "Font size name"
+						"name": "Font size name",
+						"alias": "Short font size name"
 					}
 				]
 		},


### PR DESCRIPTION
Depends on https://github.com/WordPress/gutenberg/pull/37038

In https://github.com/WordPress/gutenberg/pull/37038 Gutenberg is adding a new field to translate for the font sizes stored within a `theme.json`. This PR adds it to the i18n command.

## Setup

- See https://make.wordpress.org/cli/handbook/contributions/pull-requests/#setting-up
- To run the behat tests you also need a working mysql locally:
  - Install the packages if you don't have them. In linux: `sudo apt install jq mysql-server mysql-client php-mysql`
  - `composer install && composer behat` => it didn't setup the database for me (mysql 8) so I did;
    - `sudo mysql -u root`
    - `CREATE DATABASE IF NOT EXISTS `wp_cli_test`;`
    - `CREATE USER 'wp_cli_test'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password1';`
    - `GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost"`

## How to test

- Check out this PR locally and cd to the directory.
- `composer install`
- Edit `ThemeJsonExtractor.php` by substituting the line 148 `$json = self::remote_get( self::THEME_JSON_SOURCE );` by `$json = '';`.
- Create a new directory called `foo-theme` and create a `theme.json` file within with the following contents:

```json
{
  "version": "2",
  "settings": {
    "typography": {
      "fontSizes": [
        { "slug": "small", "size": "12px", "name": "Small", "alias": "S" }
      ]
    }
  }
}
```

- Run `vendor/bin/wp i18n make-pot foo-theme`
- Verify that there's a `foo-theme/foo-theme.pot` file and that it has the name and alias strings:

```pot
#: ...

#: theme.json
msgctxt "Font size name"
msgid "Small"
msgstr ""

#: theme.json
msgctxt "Short font size name"
msgid "S"
msgstr ""
```
