### PR TITLE
Update peast and allow dealerdirect/phpcodesniffer-composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "gettext/gettext": "^4.8",
-        "mck89/peast": "^1.13.9",
+        "mck89/peast": "^1.13.11",
         "wp-cli/wp-cli": "^2.5"
     },
     "require-dev": {
@@ -24,7 +24,10 @@
     },
     "config": {
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
fixes https://github.com/wp-cli/i18n-command/issues/297