### PR TITLE
Fix include logic where include path is subdirectory of excluded path.

### DIFF
--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -168,6 +168,7 @@ trait IterableCodeExtractor {
 
 		/** @var string $root_relative_path */
 		$root_relative_path = str_replace( static::$dir, '', $dir->getPathname() );
+		$root_relative_path = self::trim_leading_slash( $root_relative_path );
 
 		foreach ( $matchers as $path_or_file ) {
 			// If the matcher contains no wildcards and the path matches the start of the matcher.
@@ -230,6 +231,11 @@ trait IterableCodeExtractor {
 					if ( ( 0 === $inclusion_score || $exclusion_score > $inclusion_score ) && $iterator->hasChildren() ) {
 						// Always include directories that may have matching children even if they are excluded.
 						return static::containsMatchingChildren( $file, $include );
+					}
+
+					// Include directories that are excluded but include score is higher.
+					if ( 0 < $exclusion_score && $inclusion_score >= $exclusion_score && $iterator->hasChildren() ) {
+						return true;
 					}
 
 					if ( ! $file->isFile() || ! in_array( $file->getExtension(), $extensions, true ) ) {

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -234,7 +234,7 @@ trait IterableCodeExtractor {
 					}
 
 					// Include directories that are excluded but include score is higher.
-					if ( 0 < $exclusion_score && $inclusion_score >= $exclusion_score && $iterator->hasChildren() ) {
+					if ( $exclusion_score > 0 && $inclusion_score >= $exclusion_score && $iterator->hasChildren() ) {
 						return true;
 					}
 

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -132,6 +132,7 @@ class IterableCodeExtractorTest extends TestCase {
 			static::$base . 'foo/bar/foofoo/minified.min.js',
 			static::$base . 'hoge/should_NOT_be_included.js',
 			static::$base . 'vendor/vendor-file.php',
+			static::$base . 'vendor/vendor1/vendor1-file.php',
 		);
 		$this->assertEquals( $expected, $result );
 	}
@@ -141,6 +142,14 @@ class IterableCodeExtractorTest extends TestCase {
 		$excludes = [ 'vendor' ];
 		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
 		$expected = static::$base . 'vendor/vendor-file.php';
+		$this->assertContains( $expected, $result );
+	}
+
+	public function test_can_include_folder_in_excluded_folder() {
+		$includes = [ 'vendor/vendor1' ];
+		$excludes = [ 'vendor' ];
+		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, $includes, $excludes, [ 'php', 'js' ] );
+		$expected = static::$base . 'vendor/vendor1/vendor1-file.php';
 		$this->assertContains( $expected, $result );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/i18n-command/issues/172.

Changes in this PR:
- Fix `containsMatchingChildren()`, so $root_relative_path doesn't have trailing slash. [[#](https://github.com/shendy-a8c/i18n-command/blob/e52b2aa7ed2fdaa6186ef530e231e7847a54c97e/src/IterableCodeExtractor.php#L171)]. This is because [`$include` and `$exclude` are trailing-slash-trimmed](https://github.com/shendy-a8c/i18n-command/blob/e52b2aa7ed2fdaa6186ef530e231e7847a54c97e/src/IterableCodeExtractor.php#L219-L220), so if `$root_relative_path` isn't, [this clause](https://github.com/shendy-a8c/i18n-command/blob/e52b2aa7ed2fdaa6186ef530e231e7847a54c97e/src/IterableCodeExtractor.php#L178) won't be true as expected.
- When the file iterator gets to the included folder, which is a subfolder of an excluded folder, it will get [here](https://github.com/shendy-a8c/i18n-command/blob/e52b2aa7ed2fdaa6186ef530e231e7847a54c97e/src/IterableCodeExtractor.php#L242), so I created a new [if block](https://github.com/shendy-a8c/i18n-command/blob/e52b2aa7ed2fdaa6186ef530e231e7847a54c97e/src/IterableCodeExtractor.php#L236-L239) to handle that case.
- Unit test for this case: including a folder inside an excluded folder.
