### PR TITLE
Add support for PHP-Blade files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
+        "eftec/bladeone": "3.52",
         "gettext/gettext": "^4.8",
-        "illuminate/view": "^8.83",
         "mck89/peast": "^1.13.11",
         "wp-cli/wp-cli": "^2.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "gettext/gettext": "^4.8",
+        "illuminate/view": "^8.83",
         "mck89/peast": "^1.13.11",
         "wp-cli/wp-cli": "^2.5"
     },

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2911,6 +2911,52 @@ Feature: Generate a POT file of a WordPress project
       msgid "Bar"
       """
 
+  Scenario: Extract strings from a Blade-PHP file
+    Given an empty example-project directory
+    And a example-project/stuff.blade.php file:
+      """
+	  @php
+		__('Test');
+	  @endphp
+      @extends('layouts.app')
+	  
+	  @php(__('Another test.', 'domain'))
+
+      @section('content')
+        @include('partials.page-header')
+
+        @if (! have_posts())
+          <x-alert type="warning">
+            {!! __('Page not found.', 'foo-plugin') !!}
+          </x-alert>
+
+          {!! get_search_form(false) !!}
+        @endif
+      @endsection
+      """
+
+    When I try `wp i18n make-pot example-project result.pot --ignore-domain --debug`
+    Then STDOUT should be:
+      """
+      Success: POT file successfully generated!
+      """
+    And STDERR should contain:
+      """
+      No valid theme stylesheet or plugin file found, treating as a regular project.
+      """
+    And the result.pot file should contain:
+      """
+      msgid "Test"
+      """
+    And the result.pot file should contain:
+      """
+      msgid "Page not found."
+      """
+    And the result.pot file should contain:
+      """
+      msgid "Another test."
+      """
+
   Scenario: Custom package name
     Given an empty example-project directory
     And a example-project/stuff.php file:

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2911,6 +2911,7 @@ Feature: Generate a POT file of a WordPress project
       msgid "Bar"
       """
 
+  @blade
   Scenario: Extract strings from a Blade-PHP file in a theme (ignoring domains)
     Given an empty foo-theme directory
     And a foo-theme/style.css file:
@@ -2967,6 +2968,7 @@ Feature: Generate a POT file of a WordPress project
       msgid "Another test."
       """
 
+  @blade
   Scenario: Extract strings from a Blade-PHP file in a theme
     Given an empty foo-theme directory
     And a foo-theme/style.css file:

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2933,7 +2933,7 @@ Feature: Generate a POT file of a WordPress project
 		__('Test');
 	  @endphp
       @extends('layouts.app')
-	  
+
 	  @php(__('Another test.', 'some-other-domain'))
 
       @section('content')
@@ -2990,7 +2990,7 @@ Feature: Generate a POT file of a WordPress project
 		__('Test');
 	  @endphp
       @extends('layouts.app')
-	  
+
 	  @php(__('Another test.', 'some-other-domain'))
 
       @section('content')
@@ -3011,10 +3011,6 @@ Feature: Generate a POT file of a WordPress project
       """
       Theme stylesheet detected.
       Success: POT file successfully generated!
-      """
-    And the result.pot file should contain:
-      """
-      msgid "Test"
       """
     And the result.pot file should contain:
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -2911,9 +2911,23 @@ Feature: Generate a POT file of a WordPress project
       msgid "Bar"
       """
 
-  Scenario: Extract strings from a Blade-PHP file
-    Given an empty example-project directory
-    And a example-project/stuff.blade.php file:
+  Scenario: Extract strings from a Blade-PHP file in a theme
+    Given an empty foo-theme directory
+    And a foo-theme/style.css file:
+      """
+      /*
+      Theme Name:     Foo Theme
+      Theme URI:      https://example.com
+      Description:
+      Author:
+      Author URI:
+      Version:        0.1.0
+      License:        GPL-2.0+
+      Text Domain:    foo-theme
+      Domain Path:    /languages
+      */
+      """
+    And a foo-theme/stuff.blade.php file:
       """
 	  @php
 		__('Test');
@@ -2935,14 +2949,11 @@ Feature: Generate a POT file of a WordPress project
       @endsection
       """
 
-    When I try `wp i18n make-pot example-project result.pot --ignore-domain --debug`
+    When I try `wp i18n make-pot foo-theme result.pot --ignore-domain --debug`
     Then STDOUT should be:
       """
+      Theme stylesheet detected.
       Success: POT file successfully generated!
-      """
-    And STDERR should contain:
-      """
-      No valid theme stylesheet or plugin file found, treating as a regular project.
       """
     And the result.pot file should contain:
       """

--- a/src/BladeCodeExtractor.php
+++ b/src/BladeCodeExtractor.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace WP_CLI\I18n;
+
+use Exception;
+use Gettext\Extractors\Blade;
+use Gettext\Translations;
+use WP_CLI;
+
+final class BladeCodeExtractor extends Blade {
+	use IterableCodeExtractor;
+
+	public static $options = [
+		'extractComments' => [ 'translators', 'Translators' ],
+		'constants'       => [],
+		'functions'       => [
+			'__'              => 'text_domain',
+			'esc_attr__'      => 'text_domain',
+			'esc_html__'      => 'text_domain',
+			'esc_xml__'       => 'text_domain',
+			'_e'              => 'text_domain',
+			'esc_attr_e'      => 'text_domain',
+			'esc_html_e'      => 'text_domain',
+			'esc_xml_e'       => 'text_domain',
+			'_x'              => 'text_context_domain',
+			'_ex'             => 'text_context_domain',
+			'esc_attr_x'      => 'text_context_domain',
+			'esc_html_x'      => 'text_context_domain',
+			'esc_xml_x'       => 'text_context_domain',
+			'_n'              => 'single_plural_number_domain',
+			'_nx'             => 'single_plural_number_context_domain',
+			'_n_noop'         => 'single_plural_domain',
+			'_nx_noop'        => 'single_plural_context_domain',
+
+			// Compat.
+			'_'               => 'gettext', // Same as 'text_domain'.
+
+			// Deprecated.
+			'_c'              => 'text_domain',
+			'_nc'             => 'single_plural_number_domain',
+			'__ngettext'      => 'single_plural_number_domain',
+			'__ngettext_noop' => 'single_plural_domain',
+		],
+	];
+
+	protected static $functionsScannerClass = 'WP_CLI\I18n\PhpFunctionsScanner';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function fromString( $string, Translations $translations, array $options = [] ) {
+		WP_CLI::debug( "Parsing file {$options['file']}", 'make-pot' );
+
+		try {
+			parent::fromString( $string, $translations, $options ); // pass-through
+		} catch ( Exception $exception ) {
+			WP_CLI::debug(
+				sprintf(
+					'Could not parse file %1$s: %2$s',
+					$options['file'],
+					$exception->getMessage()
+				),
+				'make-pot'
+			);
+		}
+	}
+}

--- a/src/BladeCodeExtractor.php
+++ b/src/BladeCodeExtractor.php
@@ -5,7 +5,6 @@ namespace WP_CLI\I18n;
 use Exception;
 use Gettext\Translations;
 use WP_CLI;
-use WP_CLI\I18n;
 
 final class BladeCodeExtractor extends BladeGettextExtractor {
 	use IterableCodeExtractor;
@@ -52,7 +51,7 @@ final class BladeCodeExtractor extends BladeGettextExtractor {
 		WP_CLI::debug( "Parsing file {$options['file']}", 'make-pot' );
 
 		try {
-			parent::fromString( $string, $translations, $options ); // pass-through
+			static::fromStringMultiple( $string, [ $translations ], $options );
 		} catch ( Exception $exception ) {
 			WP_CLI::debug(
 				sprintf(

--- a/src/BladeCodeExtractor.php
+++ b/src/BladeCodeExtractor.php
@@ -3,11 +3,11 @@
 namespace WP_CLI\I18n;
 
 use Exception;
-use Gettext\Extractors\Blade;
 use Gettext\Translations;
 use WP_CLI;
+use WP_CLI\I18n;
 
-final class BladeCodeExtractor extends Blade {
+final class BladeCodeExtractor extends BladeGettextExtractor {
 	use IterableCodeExtractor;
 
 	public static $options = [

--- a/src/BladeGettextExtractor.php
+++ b/src/BladeGettextExtractor.php
@@ -13,6 +13,11 @@ use eftec\bladeone\BladeOne;
  */
 class BladeGettextExtractor extends \Gettext\Extractors\PhpCode {
 
+	/**
+	 * Prepares a Blade compiler/engine and returns it.
+	 *
+	 * @return BladeOne
+	 */
 	protected static function getBladeCompiler() {
 		$cache_path     = empty( $options['cachePath'] ) ? sys_get_temp_dir() : $options['cachePath'];
 		$blade_compiler = new BladeOne( null, $cache_path );
@@ -24,15 +29,20 @@ class BladeGettextExtractor extends \Gettext\Extractors\PhpCode {
 		return $blade_compiler;
 	}
 
+	/**
+	 * Compiles the Blade template string into a PHP string in one step.
+	 *
+	 * @param string $string Blade string to be compiled to a PHP string
+	 * @return string
+	 */
 	protected static function compileBladeToPhp( $string ) {
 		return static::getBladeCompiler()->compileString( $string );
 	}
 
-
-	// Note: In PhpCode class fromString() uses fromStringMultiple()
-
 	/**
 	 * {@inheritdoc}
+	 *
+	 * Note: In the parent PhpCode class fromString() uses fromStringMultiple() (overriden here)
 	 */
 	public static function fromStringMultiple( $string, array $translations, array $options = [] ) {
 		$php_string = static::compileBladeToPhp( $string );

--- a/src/BladeGettextExtractor.php
+++ b/src/BladeGettextExtractor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WP_CLI\I18n;
+
+use Gettext\Translations;
+use eftec\bladeone\BladeOne;
+
+// Modified Gettext Blade extractor that uses the up-to-date BladeOne standalone Blade engine
+
+/**
+ * Class to get gettext strings from blade.php files returning arrays.
+ */
+class BladeGettextExtractor extends \Gettext\Extractors\Extractor implements \Gettext\Extractors\ExtractorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromString($string, Translations $translations, array $options = [])
+    {
+        if (empty($options['facade'])) {
+            $cachePath = empty($options['cachePath']) ? sys_get_temp_dir() : $options['cachePath'];
+            $bladeCompiler = new BladeOne(null, $cachePath);
+
+            if (method_exists($bladeCompiler, 'withoutComponentTags')) {
+                $bladeCompiler->withoutComponentTags();
+            }
+
+            $string = $bladeCompiler->compileString($string);
+        } else {
+            $string = $options['facade']::compileString($string);
+        }
+
+        \Gettext\Extractors\PhpCode::fromString($string, $translations, $options);
+    }
+}

--- a/src/BladeGettextExtractor.php
+++ b/src/BladeGettextExtractor.php
@@ -10,26 +10,24 @@ use eftec\bladeone\BladeOne;
 /**
  * Class to get gettext strings from blade.php files returning arrays.
  */
-class BladeGettextExtractor extends \Gettext\Extractors\Extractor implements \Gettext\Extractors\ExtractorInterface
-{
-    /**
-     * {@inheritdoc}
-     */
-    public static function fromString($string, Translations $translations, array $options = [])
-    {
-        if (empty($options['facade'])) {
-            $cachePath = empty($options['cachePath']) ? sys_get_temp_dir() : $options['cachePath'];
-            $bladeCompiler = new BladeOne(null, $cachePath);
+class BladeGettextExtractor extends \Gettext\Extractors\Extractor implements \Gettext\Extractors\ExtractorInterface {
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function fromString( $string, Translations $translations, array $options = [] ) {
+		if ( empty( $options['facade'] ) ) {
+			$cache_path     = empty( $options['cachePath'] ) ? sys_get_temp_dir() : $options['cachePath'];
+			$blade_compiler = new BladeOne( null, $cache_path );
 
-            if (method_exists($bladeCompiler, 'withoutComponentTags')) {
-                $bladeCompiler->withoutComponentTags();
-            }
+			if ( method_exists( $blade_compiler, 'withoutComponentTags' ) ) {
+				$blade_compiler->withoutComponentTags();
+			}
 
-            $string = $bladeCompiler->compileString($string);
-        } else {
-            $string = $options['facade']::compileString($string);
-        }
+			$string = $blade_compiler->compileString( $string );
+		} else {
+			$string = $options['facade']::compileString( $string );
+		}
 
-        \Gettext\Extractors\PhpCode::fromString($string, $translations, $options);
-    }
+		\Gettext\Extractors\PhpCode::fromString( $string, $translations, $options );
+	}
 }

--- a/src/BladeGettextExtractor.php
+++ b/src/BladeGettextExtractor.php
@@ -2,32 +2,40 @@
 
 namespace WP_CLI\I18n;
 
-use Gettext\Translations;
 use eftec\bladeone\BladeOne;
 
-// Modified Gettext Blade extractor that uses the up-to-date BladeOne standalone Blade engine
+// Modified Gettext Blade extractor that
+// uses the up-to-date BladeOne standalone Blade engine,
+// correctly supports fromStringMultiple.
 
 /**
  * Class to get gettext strings from blade.php files returning arrays.
  */
-class BladeGettextExtractor extends \Gettext\Extractors\Extractor implements \Gettext\Extractors\ExtractorInterface {
+class BladeGettextExtractor extends \Gettext\Extractors\PhpCode {
+
+	protected static function getBladeCompiler() {
+		$cache_path     = empty( $options['cachePath'] ) ? sys_get_temp_dir() : $options['cachePath'];
+		$blade_compiler = new BladeOne( null, $cache_path );
+
+		if ( method_exists( $blade_compiler, 'withoutComponentTags' ) ) {
+			$blade_compiler->withoutComponentTags();
+		}
+
+		return $blade_compiler;
+	}
+
+	protected static function compileBladeToPhp( $string ) {
+		return static::getBladeCompiler()->compileString( $string );
+	}
+
+
+	// Note: In PhpCode class fromString() uses fromStringMultiple()
+
 	/**
 	 * {@inheritdoc}
 	 */
-	public static function fromString( $string, Translations $translations, array $options = [] ) {
-		if ( empty( $options['facade'] ) ) {
-			$cache_path     = empty( $options['cachePath'] ) ? sys_get_temp_dir() : $options['cachePath'];
-			$blade_compiler = new BladeOne( null, $cache_path );
-
-			if ( method_exists( $blade_compiler, 'withoutComponentTags' ) ) {
-				$blade_compiler->withoutComponentTags();
-			}
-
-			$string = $blade_compiler->compileString( $string );
-		} else {
-			$string = $options['facade']::compileString( $string );
-		}
-
-		\Gettext\Extractors\PhpCode::fromString( $string, $translations, $options );
+	public static function fromStringMultiple( $string, array $translations, array $options = [] ) {
+		$php_string = static::compileBladeToPhp( $string );
+		return parent::fromStringMultiple( $php_string, $translations, $options );
 	}
 }

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -264,6 +264,7 @@ trait IterableCodeExtractor {
 
 	/**
 	 * Determines whether the file extension of a file matches any of the given file extensions.
+	 * The end/last part of a multi file extension must also match (`js` of `min.js`).
 	 *
 	 * @param SplFileInfo $file       File or directory.
 	 * @param array       $extensions List of file extensions to match.

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -238,7 +238,7 @@ trait IterableCodeExtractor {
 						return true;
 					}
 
-					if ( ! $file->isFile() || ! in_array( static::file_extensions_multi( $file ), $extensions, true ) ) {
+					if ( ! $file->isFile() || ! static::file_has_file_extension( $file, $extensions ) ) {
 						return false;
 					}
 
@@ -250,7 +250,7 @@ trait IterableCodeExtractor {
 
 		foreach ( $files as $file ) {
 			/** @var SplFileInfo $file */
-			if ( ! $file->isFile() || ! in_array( static::file_extensions_multi( $file ), $extensions, true ) ) {
+			if ( ! $file->isFile() || ! static::file_has_file_extension( $file, $extensions ) ) {
 				continue;
 			}
 
@@ -262,7 +262,12 @@ trait IterableCodeExtractor {
 		return $filtered_files;
 	}
 
-	private static function file_extensions_multi( $file ) {
+	private static function file_has_file_extension( $file, $extensions ) {
+		return in_array( $file->getExtension(), $extensions, true ) ||
+			in_array( static::file_get_extension_multi( $file ), $extensions, true );
+	}
+
+	private static function file_get_extension_multi( $file ) {
 		$file_extension_separator = '.';
 
 		$filename = $file->getFilename();

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -262,11 +262,24 @@ trait IterableCodeExtractor {
 		return $filtered_files;
 	}
 
+	/**
+	 * Determines whether the file extension of a file matches any of the given file extensions.
+	 *
+	 * @param SplFileInfo $file       File or directory.
+	 * @param array       $extensions List of file extensions to match.
+	 * @return bool Whether the file has a file extension that matches any of the ones in the list.
+	 */
 	private static function file_has_file_extension( $file, $extensions ) {
 		return in_array( $file->getExtension(), $extensions, true ) ||
 			in_array( static::file_get_extension_multi( $file ), $extensions, true );
 	}
 
+	/**
+	 * Gets the single- (e.g. `php`) or multi-file extension (e.g. `blade.php`) of a file.
+	 *
+	 * @param SplFileInfo $file File or directory.
+	 * @return string The single- or multi-file extension of the file.
+	 */
 	private static function file_get_extension_multi( $file ) {
 		$file_extension_separator = '.';
 

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -238,7 +238,7 @@ trait IterableCodeExtractor {
 						return true;
 					}
 
-					if ( ! $file->isFile() || ! in_array( $file->getExtension(), $extensions, true ) ) {
+					if ( ! $file->isFile() || ! in_array( static::file_extensions_multi($file), $extensions, true ) ) {
 						return false;
 					}
 
@@ -250,7 +250,7 @@ trait IterableCodeExtractor {
 
 		foreach ( $files as $file ) {
 			/** @var SplFileInfo $file */
-			if ( ! $file->isFile() || ! in_array( $file->getExtension(), $extensions, true ) ) {
+			if ( ! $file->isFile() || ! in_array( static::file_extensions_multi($file), $extensions, true ) ) {
 				continue;
 			}
 
@@ -260,6 +260,18 @@ trait IterableCodeExtractor {
 		sort( $filtered_files, SORT_NATURAL | SORT_FLAG_CASE );
 
 		return $filtered_files;
+	}
+	
+	private static function file_extensions_multi($file) {
+		$FILE_EXTENSION_SEPARATOR = '.';
+
+		$filename = $file->getFilename();
+		$parts = explode($FILE_EXTENSION_SEPARATOR, $filename, 2);
+		if(count($parts) <= 1) {
+			// if ever something goes wrong, fall back to SPL
+			return $file->getExtension();
+		}
+		return $parts[1];
 	}
 
 	/**

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -238,7 +238,7 @@ trait IterableCodeExtractor {
 						return true;
 					}
 
-					if ( ! $file->isFile() || ! in_array( static::file_extensions_multi($file), $extensions, true ) ) {
+					if ( ! $file->isFile() || ! in_array( static::file_extensions_multi( $file ), $extensions, true ) ) {
 						return false;
 					}
 
@@ -250,7 +250,7 @@ trait IterableCodeExtractor {
 
 		foreach ( $files as $file ) {
 			/** @var SplFileInfo $file */
-			if ( ! $file->isFile() || ! in_array( static::file_extensions_multi($file), $extensions, true ) ) {
+			if ( ! $file->isFile() || ! in_array( static::file_extensions_multi( $file ), $extensions, true ) ) {
 				continue;
 			}
 
@@ -261,13 +261,13 @@ trait IterableCodeExtractor {
 
 		return $filtered_files;
 	}
-	
-	private static function file_extensions_multi($file) {
-		$FILE_EXTENSION_SEPARATOR = '.';
+
+	private static function file_extensions_multi( $file ) {
+		$file_extension_separator = '.';
 
 		$filename = $file->getFilename();
-		$parts = explode($FILE_EXTENSION_SEPARATOR, $filename, 2);
-		if(count($parts) <= 1) {
+		$parts    = explode( $file_extension_separator, $filename, 2 );
+		if ( count( $parts ) <= 1 ) {
 			// if ever something goes wrong, fall back to SPL
 			return $file->getExtension();
 		}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -620,10 +620,10 @@ class MakePotCommand extends WP_CLI_Command {
 
 			if ( ! $this->skip_blade ) {
 				$options = [
-					'include'            => $this->include,
-					'exclude'            => $this->exclude,
-					'extensions'         => [ 'blade.php' ],
-					'addReferences'      => $this->location,
+					'include'       => $this->include,
+					'exclude'       => $this->exclude,
+					'extensions'    => [ 'blade.php' ],
+					'addReferences' => $this->location,
 				];
 				BladeCodeExtractor::fromDirectory( $this->source, $translations, $options );
 			}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -620,8 +620,6 @@ class MakePotCommand extends WP_CLI_Command {
 
 			if ( ! $this->skip_blade ) {
 				$options = [
-					// Extract 'Template Name' headers in theme files.
-					'wpExtractTemplates' => isset( $this->main_file_data['Theme Name'] ),
 					'include'            => $this->include,
 					'exclude'            => $this->exclude,
 					'extensions'         => [ 'blade.php' ],

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -72,6 +72,11 @@ class MakePotCommand extends WP_CLI_Command {
 	/**
 	 * @var bool
 	 */
+	protected $skip_blade = false;
+
+	/**
+	 * @var bool
+	 */
 	protected $skip_block_json = false;
 
 	/**
@@ -163,7 +168,7 @@ class MakePotCommand extends WP_CLI_Command {
 	/**
 	 * Create a POT file for a WordPress project.
 	 *
-	 * Scans PHP and JavaScript files for translatable strings, as well as theme stylesheets and plugin files
+	 * Scans PHP, Blade-PHP and JavaScript files for translatable strings, as well as theme stylesheets and plugin files
 	 * if the source directory is detected as either a plugin or theme.
 	 *
 	 * ## OPTIONS
@@ -226,6 +231,9 @@ class MakePotCommand extends WP_CLI_Command {
 	 *
 	 * [--skip-php]
 	 * : Skips PHP string extraction.
+	 *
+	 * [--skip-blade]
+	 * : Skips Blade-PHP string extraction.
 	 *
 	 * [--skip-block-json]
 	 * : Skips string extraction from block.json files.
@@ -311,6 +319,7 @@ class MakePotCommand extends WP_CLI_Command {
 		$this->slug            = Utils\get_flag_value( $assoc_args, 'slug', Utils\basename( $this->source ) );
 		$this->skip_js         = Utils\get_flag_value( $assoc_args, 'skip-js', $this->skip_js );
 		$this->skip_php        = Utils\get_flag_value( $assoc_args, 'skip-php', $this->skip_php );
+		$this->skip_blade      = Utils\get_flag_value( $assoc_args, 'skip-blade', $this->skip_blade );
 		$this->skip_block_json = Utils\get_flag_value( $assoc_args, 'skip-block-json', $this->skip_block_json );
 		$this->skip_theme_json = Utils\get_flag_value( $assoc_args, 'skip-theme-json', $this->skip_theme_json );
 		$this->skip_audit      = Utils\get_flag_value( $assoc_args, 'skip-audit', $this->skip_audit );
@@ -607,6 +616,18 @@ class MakePotCommand extends WP_CLI_Command {
 					'addReferences'      => $this->location,
 				];
 				PhpCodeExtractor::fromDirectory( $this->source, $translations, $options );
+			}
+
+			if ( ! $this->skip_blade ) {
+				$options = [
+					// Extract 'Template Name' headers in theme files.
+					'wpExtractTemplates' => isset( $this->main_file_data['Theme Name'] ),
+					'include'            => $this->include,
+					'exclude'            => $this->exclude,
+					'extensions'         => [ 'blade.php' ],
+					'addReferences'      => $this->location,
+				];
+				BladeCodeExtractor::fromDirectory( $this->source, $translations, $options );
 			}
 
 			if ( ! $this->skip_js ) {

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -259,10 +259,11 @@ class IterableCodeExtractorTest extends TestCase {
 
 			[ 'foo-theme/foo-theme-file.blade.php', [ 'php', 'blade.php' ], true ],
 			[ 'foo-theme/foo-theme-file.blade.php', [ 'blade.php' ], true ],
-			// end/last part of a multi-extension must also matched
+			// the last part of a multi file-extension must also match single file-extensions (e.g. `min.js` matches `js`)
 			[ 'foo-theme/foo-theme-file.blade.php', [ 'js', 'php' ], true ],
 			[ 'foo-theme/foo-theme-file.blade.php', [ 'js' ], false ],
-			[ 'foo-theme/foo-theme-file.blade.php', [ 'js', 'json' ], false ],
+			[ 'foo/bar/foofoo/minified.min.js', [ 'js', 'json', 'php' ], true ],
+			[ 'foo/bar/foofoo/minified.min.js', [ 'json', 'php' ], false ],
 		];
 	}
 }

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -122,7 +122,7 @@ class IterableCodeExtractorTest extends TestCase {
 	}
 
 	public function test_can_return_all_directory_files_sorted() {
-		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ '*' ], [], [ 'php', 'js' ] );
+		$result   = IterableCodeExtractor::getFilesFromDirectory( self::$base, [ '*' ], [], [ 'php', 'blade.php', 'js' ] );
 		$expected = array(
 			static::$base . 'baz/includes/should_be_included.js',
 			static::$base . 'foo-plugin/foo-plugin.php',

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -223,28 +223,46 @@ class IterableCodeExtractorTest extends TestCase {
 		return $file_get_extension_multi_method->invokeArgs( null, [ $file, $extensions ] );
 	}
 
-	public function test_gets_file_extensions_correctly() {
-		$this->assertEquals( static::file_get_extension_multi_invoke( new \SplFileObject( self::$base . 'foo/bar/foofoo/included.js' ) ), 'js' );
-		$this->assertEquals( static::file_get_extension_multi_invoke( new \SplFileObject( self::$base . 'foo-plugin/foo-plugin.php' ) ), 'php' );
-		$this->assertEquals( static::file_get_extension_multi_invoke( new \SplFileObject( self::$base . 'foo-theme/foo-theme-file.blade.php' ) ), 'blade.php' );
+	/**
+	 * @dataProvider file_extension_extract_provider
+	 */
+	public function test_gets_file_extension_correctly( $rel_input_file, $expected_extension ) {
+		$this->assertEquals( static::file_get_extension_multi_invoke( new \SplFileObject( self::$base . $rel_input_file ) ), $expected_extension );
 	}
 
-	public function test_matches_file_extensions_correctly() {
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo/bar/foofoo/included.js' ), [ 'js' ] ), true );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo/bar/foofoo/included.js' ), [ 'js', 'php', 'blade.php' ] ), true );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo/bar/foofoo/included.js' ), [ 'php' ] ), false );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo/bar/foofoo/included.js' ), [ 'php', 'blade.php' ] ), false );
+	public function file_extension_extract_provider() {
+		return [
+			[ 'foo/bar/foofoo/included.js', 'js' ],
+			[ 'foo-plugin/foo-plugin.php', 'php' ],
+			[ 'foo-theme/foo-theme-file.blade.php', 'blade.php' ],
+		];
+	}
 
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-plugin/foo-plugin.php' ), [ 'php', 'js' ] ), true );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-plugin/foo-plugin.php' ), [ 'php', 'blade.php' ] ), true );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-plugin/foo-plugin.php' ), [ 'blade.php', 'js' ] ), false );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-plugin/foo-plugin.php' ), [ 'js', 'blade.php' ] ), false );
+	/**
+	 * @dataProvider file_extensions_matches_provider
+	 */
+	public function test_matches_file_extensions_correctly( $rel_input_file, $matching_extensions, $expected_result ) {
+		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . $rel_input_file ), $matching_extensions ), $expected_result );
+	}
 
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-theme/foo-theme-file.blade.php' ), [ 'php', 'blade.php', 'js' ] ), true );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-theme/foo-theme-file.blade.php' ), [ 'blade.php' ] ), true );
-		// end/last part of a multi-extension must also matched
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-theme/foo-theme-file.blade.php' ), [ 'js', 'php' ] ), true );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-theme/foo-theme-file.blade.php' ), [ 'js' ] ), false );
-		$this->assertEquals( static::file_has_file_extension_invoke( new \SplFileObject( self::$base . 'foo-theme/foo-theme-file.blade.php' ), [ 'js', 'json' ] ), false );
+	public function file_extensions_matches_provider() {
+		return [
+			[ 'foo/bar/foofoo/included.js', [ 'js' ], true ],
+			[ 'foo/bar/foofoo/included.js', [ 'js', 'php', 'blade.php' ], true ],
+			[ 'foo/bar/foofoo/included.js', [ 'php' ], false ],
+			[ 'foo/bar/foofoo/included.js', [ 'php', 'blade.php' ], false ],
+
+			[ 'foo-plugin/foo-plugin.php', [ 'php', 'js' ], true ],
+			[ 'foo-plugin/foo-plugin.php', [ 'php', 'blade.php' ], true ],
+			[ 'foo-plugin/foo-plugin.php', [ 'blade.php', 'js' ], false ],
+			[ 'foo-plugin/foo-plugin.php', [ 'js', 'blade.php' ], false ],
+
+			[ 'foo-theme/foo-theme-file.blade.php', [ 'php', 'blade.php' ], true ],
+			[ 'foo-theme/foo-theme-file.blade.php', [ 'blade.php' ], true ],
+			// end/last part of a multi-extension must also matched
+			[ 'foo-theme/foo-theme-file.blade.php', [ 'js', 'php' ], true ],
+			[ 'foo-theme/foo-theme-file.blade.php', [ 'js' ], false ],
+			[ 'foo-theme/foo-theme-file.blade.php', [ 'js', 'json' ], false ],
+		];
 	}
 }

--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -126,6 +126,7 @@ class IterableCodeExtractorTest extends TestCase {
 		$expected = array(
 			static::$base . 'baz/includes/should_be_included.js',
 			static::$base . 'foo-plugin/foo-plugin.php',
+			static::$base . 'foo-theme/foo-theme-file.blade.php',
 			static::$base . 'foo/bar/excluded/ignored.js',
 			static::$base . 'foo/bar/foo/bar/foo/bar/deep_directory_also_included.php',
 			static::$base . 'foo/bar/foofoo/included.js',


### PR DESCRIPTION
This PR adds the code and (simple) tests for extracting translations strings from PHP-Blade template files.

Luckily the [`4.x` branch of the `gettext` project already contains a fully working PHP-Blade Extractor](https://github.com/php-gettext/Gettext/blob/4.x/src/Extractors/Blade.php), 
which can be used very similarly to the PHP extractor for `wp i18n`.

The `IterableCodeExtractor` file filter [had to be refactored](https://github.com/wp-cli/i18n-command/pull/304/files#diff-6dbbabe411870b35fac549f92d2c059e9cc16d2f0f85b37347393150a9f3e7c1) a bit to make it also support filtering for multiple file extensions (as it is the case with `blade.php` for PHP-Blade template files).

The ~~`illuminate/view`~~ `BladeOne` compiler for a standalone PHP-Blade compiler [had to be included as `composer` dependency](https://github.com/wp-cli/i18n-command/pull/304/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R15) as the `gettext` package doesn't require it on its own/expects a PHP-Blade compiler to be available. Edit: Because of current PHP version constraints by `i18n`, a release of another, standalone and well-maintained PHP-Blade compiler is used instead (`BladeOne`).

### Discussion
Both classes, `PhpCodeExtractor` and `BladeCodeExtractor`  duplicate some code, `$options` and `$functionsScannerClass`:
https://github.com/strarsis/i18n-command/blob/add-blade-extractor/src/PhpCodeExtractor.php#L13-L46
https://github.com/strarsis/i18n-command/blob/add-blade-extractor/src/BladeCodeExtractor.php#L13-L46

Side note: Putting these two aforementioned fields `$options` and `$functionsScannerClass` into a PHP `trait` doesn't work as PHP `trait`s can't override class fields (as I learned by trying to do so).
Both classes have to extend from a class from `gettext/gettext`, therefore a trivial way for letting both classes share these fields doesn't seem to exist, so I think those duplications (which are quite compact) can be tolerated.