### PR TITLE
Translate `title` field from `theme.json`

### DIFF
--- a/assets/theme-i18n.json
+++ b/assets/theme-i18n.json
@@ -1,4 +1,5 @@
 {
+	"name": "Name of the style variation",
 	"settings": {
 		"typography": {
 				"fontSizes": [

--- a/assets/theme-i18n.json
+++ b/assets/theme-i18n.json
@@ -1,5 +1,5 @@
 {
-	"title": "Style variation title",
+	"title": "Style variation name",
 	"settings": {
 		"typography": {
 				"fontSizes": [

--- a/assets/theme-i18n.json
+++ b/assets/theme-i18n.json
@@ -1,5 +1,5 @@
 {
-	"name": "Name of the style variation",
+	"title": "Style variation title",
 	"settings": {
 		"typography": {
 				"fontSizes": [

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3591,7 +3591,7 @@ Feature: Generate a POT file of a WordPress project
       """
     And the foo-theme/foo-theme.pot file should contain:
       """
-      msgctxt "Style variation title"
+      msgctxt "Style variation name"
       msgid "My style variation"
       """
 

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3501,7 +3501,6 @@ Feature: Generate a POT file of a WordPress project
       msgid "Notice"
       """
 
-
   Scenario: Skips theme.json file if skip-theme-json flag provided
     Given an empty foo-theme directory
     And a foo-theme/theme.json file:
@@ -3536,6 +3535,7 @@ Feature: Generate a POT file of a WordPress project
       """
       {
         "version": "1",
+        "title": "My style variation",
         "settings": {
           "color": {
             "duotone": [
@@ -3588,6 +3588,11 @@ Feature: Generate a POT file of a WordPress project
       """
       msgctxt "Font size name"
       msgid "Small"
+      """
+    And the foo-theme/foo-theme.pot file should contain:
+      """
+      msgctxt "Style variation title"
+      msgid "My style variation"
       """
 
   Scenario: Extract strings from the blocks section of theme.json files

--- a/src/ThemeJsonExtractor.php
+++ b/src/ThemeJsonExtractor.php
@@ -77,7 +77,16 @@ final class ThemeJsonExtractor extends Extractor implements ExtractorInterface {
 					}
 				}
 			} else {
-				$array_to_translate = self::array_get( $theme_json, $path );
+				if ( empty( $path ) ) {
+					// We want to translate a top-level key, so we extract it.
+					$array_to_translate = [
+						[
+							$key => $theme_json[ $key ]
+						]
+					];
+				} else {
+					$array_to_translate = self::array_get( $theme_json, $path );
+				}
 				if ( null === $array_to_translate ) {
 					continue;
 				}
@@ -207,6 +216,14 @@ final class ThemeJsonExtractor extends Extractor implements ExtractorInterface {
 	private static function extract_paths_to_translate( $i18n_partial, $current_path = [] ) {
 		$result = [];
 		foreach ( $i18n_partial as $property => $partial_child ) {
+			if ( is_string( $partial_child ) ) {
+				$result[] = [
+					'path'    => $current_path,
+					'key'     => $property,
+					'context' => $partial_child,
+				];
+				continue;
+			}
 			if ( is_numeric( $property ) ) {
 				foreach ( $partial_child as $key => $context ) {
 					$result[] = [

--- a/src/ThemeJsonExtractor.php
+++ b/src/ThemeJsonExtractor.php
@@ -81,8 +81,8 @@ final class ThemeJsonExtractor extends Extractor implements ExtractorInterface {
 					// We want to translate a top-level key, so we extract it.
 					$array_to_translate = [
 						[
-							$key => $theme_json[ $key ]
-						]
+							$key => $theme_json[ $key ],
+						],
 					];
 				} else {
 					$array_to_translate = self::array_get( $theme_json, $path );

--- a/src/ThemeJsonExtractor.php
+++ b/src/ThemeJsonExtractor.php
@@ -51,7 +51,8 @@ final class ThemeJsonExtractor extends Extractor implements ExtractorInterface {
 			 * One example of such a path would be:
 			 * [ 'settings', 'blocks', '*', 'color', 'palette' ]
 			 */
-			$nodes_to_iterate = array_keys( $path, '*', true );
+			$nodes_to_iterate   = array_keys( $path, '*', true );
+			$array_to_translate = null;
 			if ( ! empty( $nodes_to_iterate ) ) {
 				/*
 				 * At the moment, we only need to support one '*' in the path, so take it directly.
@@ -77,16 +78,19 @@ final class ThemeJsonExtractor extends Extractor implements ExtractorInterface {
 					}
 				}
 			} else {
-				if ( empty( $path ) ) {
-					// We want to translate a top-level key, so we extract it.
+				// We want to translate a top-level key, so we extract it if it exists.
+				if ( empty( $path ) && ! empty( $theme_json[ $key ] ) ) {
 					$array_to_translate = [
 						[
 							$key => $theme_json[ $key ],
 						],
 					];
-				} else {
+				}
+
+				if ( ! empty( $path ) ) {
 					$array_to_translate = self::array_get( $theme_json, $path );
 				}
+
 				if ( null === $array_to_translate ) {
 					continue;
 				}


### PR DESCRIPTION
Related https://github.com/wp-cli/i18n-command/pull/254 https://github.com/wp-cli/i18n-command/pull/292

In https://github.com/WordPress/gutenberg/pull/39322 and https://github.com/WordPress/gutenberg/pull/39715 the Gutenberg plugin has added a new translatable field to `theme.json` files, which will be part of WordPress 6.0.

This PR does a few things:

- Adds the new field to the local i18n schema.
- Updates the code so top-level keys are picked up for translation.
- Updates the code so strings are translatable (in addition to leaf arrays, as it works now).

## How to test

Automated tests:

`composer behat -- features/makepot.feature`

Manual test:

- Check out this PR locally and cd to the directory.
- `composer install`
- Comment [this line](https://github.com/wp-cli/i18n-command/blob/main/src/ThemeJsonExtractor.php#L148) in the `ThemeJsonExtractor` class, so the command uses the local backup file (`assets/theme-i18n.json`).
- Create a new directory called `foo-theme` that contains a `theme.json` file with the following contents:

```json
{
    "title": "My style variation"
}
```

- Run `vendor/bin/wp i18n make-pot foo-theme`
- Verify that there's a `foo-theme/foo-theme.pot` file and that the "My style variation" string is present as well as its context "Style variation name". You should see something like:

```
msgctxt "Style variation name"
msgid "My style variation"
msgstr ""
```
