### PR TITLE
Look for `theme.json` files in the `styles` directory of a theme

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3621,3 +3621,35 @@ Feature: Generate a POT file of a WordPress project
       msgctxt "Color name"
       msgid "Black"
       """
+
+  Scenario: Extract strings from style variations
+    Given an empty foo-theme/styles directory
+    And a foo-theme/styles/my-style.json file:
+      """
+      {
+        "version": "1",
+        "settings": {
+          "blocks": {
+            "core/paragraph": {
+              "color": {
+                "palette": [
+                  { "slug": "black", "color": "#000000", "name": "Black" }
+                ]
+              }
+            }
+          }
+        }
+      }
+      """
+    
+    When I try `wp i18n make-pot foo-theme`
+    Then STDOUT should be:
+      """
+      Success: POT file successfully generated!
+      """
+    And the foo-theme/foo-theme.pot file should exist
+    And the foo-theme/foo-theme.pot file should contain:
+      """
+      msgctxt "Color name"
+      msgid "Black"
+      """

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -687,9 +687,9 @@ class MakePotCommand extends WP_CLI_Command {
 					$this->source,
 					$translations,
 					[
-						'include'           => array_merge( $this->include, array( 'styles' ) ),
-						'exclude'           => $this->exclude,
-						'extensions'        => [ 'json' ],
+						'include'    => array_merge( $this->include, array( 'styles' ) ),
+						'exclude'    => $this->exclude,
+						'extensions' => [ 'json' ],
 					]
 				);
 			}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -668,13 +668,26 @@ class MakePotCommand extends WP_CLI_Command {
 			}
 
 			if ( ! $this->skip_theme_json ) {
+				// Look for the top-level theme.json file, nothing else.
 				ThemeJsonExtractor::fromDirectory(
 					$this->source,
 					$translations,
 					[
-						// Only look for theme.json files, nothing else.
 						'restrictFileNames' => [ 'theme.json' ],
 						'include'           => $this->include,
+						'exclude'           => $this->exclude,
+						'extensions'        => [ 'json' ],
+					]
+				);
+			}
+
+			if ( ! $this->skip_theme_json ) {
+				// Look for any JSON file within the 'styles' directory.
+				ThemeJsonExtractor::fromDirectory(
+					$this->source,
+					$translations,
+					[
+						'include'           => array_merge( $this->include, array( 'styles' ) ),
 						'exclude'           => $this->exclude,
 						'extensions'        => [ 'json' ],
 					]


### PR DESCRIPTION
This PR is a continuation of https://github.com/wp-cli/i18n-command/pull/306

It adds supports for looking for translatable strings in JSON files within the `styles` directory of a theme. Unlike the top-level `theme.json` file we don't lock any names in this case: any JSON file within the `styles` folder is a candidate we should consider.

## How to test

Automated tests:

`composer behat -- features/makepot.feature`

Manual test:

- Check out this PR locally and cd to the directory.
- `composer install`
- Create a new directory called `foo-theme` that contains a `styles` directory.
- Within the `styles` directory create a `my-style.json` file with the following contents:

```json
{
  "settings": {
    "color": {
      "palette": [ { "name": "My color", "slug": "slug", "color": "value" } ]
    }
  }
}
```

- Run `vendor/bin/wp i18n make-pot foo-theme`
- Verify that there's a `foo-theme/foo-theme.pot` file and that the "My color" string is present as well as its context "Color name". You should see something like:

```
msgctxt "Color name"
msgid "My color"
msgstr ""
```
