### PR TITLE
Extract pattern metadata (title & description)

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3658,3 +3658,41 @@ Feature: Generate a POT file of a WordPress project
       msgctxt "Color name"
       msgid "Black"
       """
+
+  @patterns
+  Scenario: Extract strings from the patterns directory
+    Given an empty foo-theme/patterns directory
+    And a foo-theme/patterns/my-pattern.php file:
+      """
+      <?php
+      /**
+       * Title: My pattern title.
+       * Description: My pattern description.
+       */
+      """
+    And a foo-theme/style.css file:
+      """
+      /*
+      Theme Name: foo theme
+      */
+      """
+
+    When I try `wp i18n make-pot foo-theme`
+    Then STDOUT should be:
+      """
+      Theme stylesheet detected.
+      Success: POT file successfully generated!
+      """
+    And the foo-theme/foo-theme.pot file should exist
+    And the foo-theme/foo-theme.pot file should contain:
+      """
+      #: patterns/my-pattern.php
+      msgctxt "Pattern title"
+      msgid "My pattern title."
+      msgstr ""
+
+      #: patterns/my-pattern.php
+      msgctxt "Pattern description"
+      msgid "My pattern description."
+      msgstr ""
+      """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3659,7 +3659,6 @@ Feature: Generate a POT file of a WordPress project
       msgid "Black"
       """
 
-  @patterns
   Scenario: Extract strings from the patterns directory
     Given an empty foo-theme/patterns directory
     And a foo-theme/patterns/my-pattern.php file:

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -67,7 +67,13 @@ trait IterableCodeExtractor {
 			}
 
 			if ( ! empty( $options['wpExtractPatterns'] ) ) {
-				$headers = MakePotCommand::get_file_data_from_string( $string, [ 'Title' => 'Title', 'Description' => 'Description' ] );
+				$headers = MakePotCommand::get_file_data_from_string(
+					$string,
+					[
+						'Title'       => 'Title',
+						'Description' => 'Description',
+					]
+				);
 
 				if ( ! empty( $headers['Title'] ) ) {
 					$translation = new Translation( '', $headers['Title'] );

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -24,7 +24,7 @@ trait IterableCodeExtractor {
 	 *     Optional. An array of options passed down to static::fromString()
 	 *
 	 *     @type bool  $wpExtractTemplates Extract 'Template Name' headers in theme files. Default 'false'.
-	 *     @type bool  $wpExtractPatterns  Extract 'Title' headers in pattern files. Default 'false'.
+	 *     @type bool  $wpExtractPatterns  Extract 'Title' and 'Description' headers in pattern files. Default 'false'.
 	 *     @type array $restrictFileNames  Skip all files which are not included in this array.
 	 * }
 	 * @return null

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -76,14 +76,14 @@ trait IterableCodeExtractor {
 				);
 
 				if ( ! empty( $headers['Title'] ) ) {
-					$translation = new Translation( 'Title of the pattern', $headers['Title'] );
+					$translation = new Translation( 'Pattern title', $headers['Title'] );
 					$translation->addReference( $options[ 'file' ] );
 
 					$translations[] = $translation;
 				}
 
 				if ( ! empty( $headers['Description'] ) ) {
-					$translation = new Translation( 'Description of the pattern', $headers['Description'] );
+					$translation = new Translation( 'Pattern description', $headers['Description'] );
 					$translation->addReference( $options[ 'file' ] );
 
 					$translations[] = $translation;

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -76,15 +76,15 @@ trait IterableCodeExtractor {
 				);
 
 				if ( ! empty( $headers['Title'] ) ) {
-					$translation = new Translation( '', $headers['Title'] );
-					$translation->addExtractedComment( 'Title of the pattern' );
+					$translation = new Translation( 'Title of the pattern', $headers['Title'] );
+					$translation->addReference( $options[ 'file' ] );
 
 					$translations[] = $translation;
 				}
 
 				if ( ! empty( $headers['Description'] ) ) {
-					$translation = new Translation( '', $headers['Description'] );
-					$translation->addExtractedComment( 'Description of the pattern' );
+					$translation = new Translation( 'Description of the pattern', $headers['Description'] );
+					$translation->addReference( $options[ 'file' ] );
 
 					$translations[] = $translation;
 				}

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -24,6 +24,7 @@ trait IterableCodeExtractor {
 	 *     Optional. An array of options passed down to static::fromString()
 	 *
 	 *     @type bool  $wpExtractTemplates Extract 'Template Name' headers in theme files. Default 'false'.
+	 *     @type bool  $wpExtractPatterns  Extract 'Title' headers in pattern files. Default 'false'.
 	 *     @type array $restrictFileNames  Skip all files which are not included in this array.
 	 * }
 	 * @return null
@@ -60,6 +61,17 @@ trait IterableCodeExtractor {
 				if ( ! empty( $headers['Template Name'] ) ) {
 					$translation = new Translation( '', $headers['Template Name'] );
 					$translation->addExtractedComment( 'Template Name of the theme' );
+
+					$translations[] = $translation;
+				}
+			}
+
+			if ( ! empty( $options['wpExtractPatterns'] ) ) {
+				$headers = MakePotCommand::get_file_data_from_string( $string, [ 'Title' => 'Title' ] );
+
+				if ( ! empty( $headers['Title'] ) ) {
+					$translation = new Translation( '', $headers['Title'] );
+					$translation->addExtractedComment( 'Title of the pattern' );
 
 					$translations[] = $translation;
 				}

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -77,14 +77,14 @@ trait IterableCodeExtractor {
 
 				if ( ! empty( $headers['Title'] ) ) {
 					$translation = new Translation( 'Pattern title', $headers['Title'] );
-					$translation->addReference( $options[ 'file' ] );
+					$translation->addReference( $options['file'] );
 
 					$translations[] = $translation;
 				}
 
 				if ( ! empty( $headers['Description'] ) ) {
 					$translation = new Translation( 'Pattern description', $headers['Description'] );
-					$translation->addReference( $options[ 'file' ] );
+					$translation->addReference( $options['file'] );
 
 					$translations[] = $translation;
 				}

--- a/src/IterableCodeExtractor.php
+++ b/src/IterableCodeExtractor.php
@@ -67,11 +67,18 @@ trait IterableCodeExtractor {
 			}
 
 			if ( ! empty( $options['wpExtractPatterns'] ) ) {
-				$headers = MakePotCommand::get_file_data_from_string( $string, [ 'Title' => 'Title' ] );
+				$headers = MakePotCommand::get_file_data_from_string( $string, [ 'Title' => 'Title', 'Description' => 'Description' ] );
 
 				if ( ! empty( $headers['Title'] ) ) {
 					$translation = new Translation( '', $headers['Title'] );
 					$translation->addExtractedComment( 'Title of the pattern' );
+
+					$translations[] = $translation;
+				}
+
+				if ( ! empty( $headers['Description'] ) ) {
+					$translation = new Translation( '', $headers['Description'] );
+					$translation->addExtractedComment( 'Description of the pattern' );
 
 					$translations[] = $translation;
 				}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -620,7 +620,7 @@ class MakePotCommand extends WP_CLI_Command {
 
 			if ( ! $this->skip_php ) {
 				$options = [
-					// Extract 'Title' headers from pattern files.
+					// Extract 'Title' and 'Description' headers from pattern files.
 					'wpExtractPatterns' => isset( $this->main_file_data['Theme Name'] ),
 					'include'           => array_merge( $this->include, array( 'patterns' ) ),
 					'exclude'           => $this->exclude,

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -618,6 +618,17 @@ class MakePotCommand extends WP_CLI_Command {
 				PhpCodeExtractor::fromDirectory( $this->source, $translations, $options );
 			}
 
+			if ( ! $this->skip_php ) {
+				$options = [
+					// Extract 'Title' headers from pattern files.
+					'wpExtractPatterns' => isset( $this->main_file_data['Theme Name'] ),
+					'include'           => array_merge( $this->include, array( 'patterns' ) ),
+					'exclude'           => $this->exclude,
+					'extensions'        => [ 'php' ],
+				];
+				PhpCodeExtractor::fromDirectory( $this->source, $translations, $options );
+			}
+
 			if ( ! $this->skip_blade ) {
 				$options = [
 					'include'       => $this->include,


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/36751 Gutenberg added the ability to automatically register patterns that live in the `/patterns` directory. These patterns provide metadata via headers in the PHP file as in:

```php
<?php
/**
 * Title: My heading
 * Description: My pattern description.
 * Slug: my-theme/my-heading
 * Categories: text
 */
```

From the existing metadata, we need the `Title` to be translatable. This PR adds support for looking up those patterns and extracting the Title string into the pot file.

## How to test

- Pull this PR and create a `foo-theme` directory at the top-level, which contains the following files:

`style.css` with at least these contents:

```css
/*
Theme Name: foo theme
*/
```

`patterns/my-pattern.php` with at least these contents:

```php
<?php

/**
 * Title: My pattern title.
 * Description: My pattern description.
 */
```

- Execute

```sh
composer install
vendor/bin/wp i18n make-pot foo-theme
```

- Verify that a new `foo-theme/foo-theme.pot` file has been generated and that contains the pattern title and the theme name. You should get something along these lines:

```po
# some other file header metadata

#. Theme Name of the theme
msgid "foo theme"
msgstr ""

#: patterns/my-pattern.php
msgctxt "Pattern title"
msgid "My pattern title."
msgstr ""

#: patterns/my-pattern.php
msgctxt "Pattern description"
msgid "My pattern description."
msgstr ""
```
