### PR TITLE
Add update-po command

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,3 +26,5 @@ labels:
     color: c5def5
   - name: command:i18n-make-json
     color: c5def5
+  - name: command:i18n-update-po
+    color: c5def5

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "commands": [
             "i18n",
             "i18n make-pot",
-            "i18n make-json"
+            "i18n make-json",
+            "i18n update-po"
         ]
     },
     "autoload": {

--- a/features/makejson.feature
+++ b/features/makejson.feature
@@ -1,7 +1,7 @@
 Feature: Split PO files into JSON files.
 
   Background:
-    Given a WP install
+    Given an empty directory
 
   Scenario: Bail for invalid source file or directory
     When I try `wp i18n make-json foo`
@@ -662,7 +662,7 @@ Feature: Split PO files into JSON files.
       """
       "lang":"invalid"
       """
-  
+
   Scenario: Should translate with single map file
     Given an empty foo-plugin directory
     And an empty foo-plugin/build directory
@@ -696,7 +696,7 @@ Feature: Split PO files into JSON files.
       msgid "Title"
       msgstr "Titel"
       """
-    
+
     When I run `wp i18n make-json languages --use-map=build/map.json` from 'foo-plugin'
     Then STDOUT should contain:
       """
@@ -707,7 +707,7 @@ Feature: Split PO files into JSON files.
       """
       "source":"build\/index.js"
       """
-  
+
   Scenario: Should translate with custom map files, mapping one input to multiple outputs
     Given an empty foo-plugin directory
     And an empty foo-plugin/build directory
@@ -747,7 +747,7 @@ Feature: Split PO files into JSON files.
       msgid "Title"
       msgstr "Titel"
       """
-    
+
     When I run `wp i18n make-json languages '--use-map=["build/map1.json","build/map2.json"]'` from 'foo-plugin'
     Then STDOUT should contain:
       """
@@ -762,7 +762,7 @@ Feature: Split PO files into JSON files.
       """
       "source":"build\/other.js"
       """
-  
+
   Scenario: Should remove translations not mapped
     Given an empty foo-plugin directory
     And an empty foo-plugin/build directory
@@ -796,14 +796,14 @@ Feature: Split PO files into JSON files.
       msgid "Text"
       msgstr "Text"
       """
-    
+
     When I try `wp i18n make-json languages --use-map=build/map.json` from 'foo-plugin'
     Then STDOUT should contain:
       """
       Success: Created 0 files.
       """
     And the return code should be 0
-  
+
   Scenario: Should ignore nonexistant files given as map
     Given an empty foo-plugin directory
 
@@ -816,7 +816,7 @@ Feature: Split PO files into JSON files.
       """
       No valid keys found. No file was created.
       """
-  
+
   Scenario: Should ignore invalid files given as map
     Given an empty foo-plugin directory
     And a foo-plugin/invalid.json file:
@@ -829,7 +829,7 @@ Feature: Split PO files into JSON files.
       """
       Map file foo-plugin/invalid.json invalid
       """
-  
+
   Scenario: Should be able to use given objects as map
     Given an empty foo-plugin directory
     And an empty foo-plugin/languages directory
@@ -856,7 +856,7 @@ Feature: Split PO files into JSON files.
       msgid "Title"
       msgstr "Titel"
       """
-    
+
     When I run `wp i18n make-json languages '--use-map={"src/index.js": "build/index.js"}'` from 'foo-plugin'
     Then STDOUT should contain:
       """
@@ -867,7 +867,7 @@ Feature: Split PO files into JSON files.
       """
       "source":"build\/index.js"
       """
-  
+
   Scenario: Should translate with custom map file and inline map, mapping one input to multiple outputs
     Given an empty foo-plugin directory
     And an empty foo-plugin/build directory
@@ -901,7 +901,7 @@ Feature: Split PO files into JSON files.
       msgid "Title"
       msgstr "Titel"
       """
-    
+
     When I run `wp i18n make-json languages '--use-map=[{"src/index.js": "build/index.js"},"build/map.json"]'` from 'foo-plugin'
     Then STDOUT should contain:
       """

--- a/features/makemo.feature
+++ b/features/makemo.feature
@@ -1,7 +1,7 @@
 Feature: Generate MO files from PO files
 
   Background:
-    Given a WP install
+    Given an empty directory
 
   Scenario: Bail for invalid source directories
     When I try `wp i18n make-mo foo`

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1,7 +1,7 @@
 Feature: Generate a POT file of a WordPress project
 
   Background:
-    Given a WP install
+    Given an empty directory
 
   Scenario: Bail for invalid source directories
     When I try `wp i18n make-pot foo bar/baz.pot`
@@ -3646,7 +3646,7 @@ Feature: Generate a POT file of a WordPress project
         }
       }
       """
-    
+
     When I try `wp i18n make-pot foo-theme`
     Then STDOUT should be:
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1,7 +1,7 @@
 Feature: Generate a POT file of a WordPress project
 
   Background:
-    Given an empty directory
+    Given a WP install
 
   Scenario: Bail for invalid source directories
     When I try `wp i18n make-pot foo bar/baz.pot`

--- a/features/updatepo.feature
+++ b/features/updatepo.feature
@@ -1,0 +1,332 @@
+Feature: Update existing PO files from a POT file
+
+  Background:
+    Given an empty directory
+
+  Scenario: Bail for invalid source file
+    When I try `wp i18n update-po bar/baz.pot`
+    Then STDERR should contain:
+      """
+      Error: Source file does not exist!
+      """
+    And the return code should be 1
+
+  Scenario: Does nothing if there are no PO files
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr ""
+      """
+
+    When I run `wp i18n update-po foo-plugin/foo-plugin.pot`
+    Then STDOUT should be:
+      """
+      Success: Updated 0 files.
+      """
+    And STDERR should be empty
+
+  Scenario: Updates all PO files in the source directory by default
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr ""
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #. translators: Old Comment.
+      #: foo-plugin.php:10
+      msgid "Some string"
+      msgstr "Some translated string"
+      """
+
+    When I run `wp i18n update-po foo-plugin/foo-plugin.pot`
+    Then STDOUT should be:
+      """
+      Success: Updated 1 file.
+      """
+    And STDERR should be empty
+    And the foo-plugin/foo-plugin-de_DE.po file should contain:
+      """
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr "Some translated string"
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """
+    And the foo-plugin/foo-plugin-de_DE.po file should not contain:
+      """
+      #. translators: Old Comment.
+      """
+    And the foo-plugin/foo-plugin-de_DE.po file should not contain:
+      """
+      #: foo-plugin.php:10
+      """
+
+  Scenario: Updates the specified target PO file
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr ""
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #. translators: Old Comment.
+      #: foo-plugin.php:10
+      msgid "Some string"
+      msgstr "Some translated string"
+      """
+    And a foo-plugin/foo-plugin-es_ES.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #. translators: Old Comment.
+      #: foo-plugin.php:10
+      msgid "Some string"
+      msgstr "Some translated string"
+      """
+
+    When I run `wp i18n update-po foo-plugin/foo-plugin.pot foo-plugin/foo-plugin-de_DE.po`
+    Then STDOUT should be:
+      """
+      Success: Updated 1 file.
+      """
+    And STDERR should be empty
+    And the foo-plugin/foo-plugin-de_DE.po file should contain:
+      """
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr "Some translated string"
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """
+    And the foo-plugin/foo-plugin-es_ES.po file should contain:
+      """
+      #. translators: Old Comment.
+      """
+    And the foo-plugin/foo-plugin-es_ES.po file should contain:
+      """
+      #: foo-plugin.php:10
+      """
+
+  Scenario: Updates all PO files in the specified target directory
+    Given an empty source directory
+    And an empty target directory
+    And a source/foo-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr ""
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """
+    And a target/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #. translators: Old Comment.
+      #: foo-plugin.php:10
+      msgid "Some string"
+      msgstr "Some translated string"
+      """
+    And a target/foo-plugin-es_ES.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #. translators: Old Comment.
+      #: foo-plugin.php:10
+      msgid "Some string"
+      msgstr "Some translated string"
+      """
+
+    When I run `wp i18n update-po source/foo-plugin.pot target`
+    Then STDOUT should be:
+      """
+      Success: Updated 2 files.
+      """
+    And STDERR should be empty
+    And the target/foo-plugin-de_DE.po file should contain:
+      """
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr "Some translated string"
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """
+    And the target/foo-plugin-es_ES.po file should contain:
+      """
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr "Some translated string"
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """

--- a/features/updatepo.feature
+++ b/features/updatepo.feature
@@ -69,6 +69,10 @@ Feature: Update existing PO files from a POT file
       #: foo-plugin.php:15
       msgid "Another new string"
       msgstr ""
+
+      #: foo-plugin.php:30
+      msgid "You have %d new message"
+      msgid_plural "You have %d new messages"
       """
     And a foo-plugin/foo-plugin-de_DE.po file:
       """
@@ -93,6 +97,12 @@ Feature: Update existing PO files from a POT file
       #: foo-plugin.php:10
       msgid "Some string"
       msgstr "Some translated string"
+
+      #: foo-plugin.php:60
+      msgid "You have %d new message"
+      msgid_plural "You have %d new messages"
+      msgstr[0] "Sie haben %d neue Nachricht"
+      msgstr[1] "Sie haben %d neue Nachrichten"
       """
 
     When I run `wp i18n update-po foo-plugin/foo-plugin.pot`
@@ -107,10 +117,20 @@ Feature: Update existing PO files from a POT file
       #: foo-plugin.php:1
       msgid "Some string"
       msgstr "Some translated string"
-
+      """
+    And the foo-plugin/foo-plugin-de_DE.po file should contain:
+      """
       #: foo-plugin.php:15
       msgid "Another new string"
       msgstr ""
+      """
+    And the foo-plugin/foo-plugin-de_DE.po file should contain:
+      """
+      #: foo-plugin.php:30
+      msgid "You have %d new message"
+      msgid_plural "You have %d new messages"
+      msgstr[0] "Sie haben %d neue Nachricht"
+      msgstr[1] "Sie haben %d neue Nachrichten"
       """
     And the foo-plugin/foo-plugin-de_DE.po file should not contain:
       """

--- a/i18n-command.php
+++ b/i18n-command.php
@@ -29,3 +29,5 @@ WP_CLI::add_command(
 WP_CLI::add_command( 'i18n make-json', '\WP_CLI\I18n\MakeJsonCommand' );
 
 WP_CLI::add_command( 'i18n make-mo', '\WP_CLI\I18n\MakeMoCommand' );
+
+WP_CLI::add_command( 'i18n update-po', '\WP_CLI\I18n\UpdatePoCommand' );

--- a/src/UpdatePoCommand.php
+++ b/src/UpdatePoCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace WP_CLI\I18n;
+
+use DirectoryIterator;
+use Gettext\Extractors\Po;
+use Gettext\Merge;
+use Gettext\Translations;
+use IteratorIterator;
+use SplFileInfo;
+use WP_CLI;
+use WP_CLI\Utils;
+use WP_CLI_Command;
+
+class UpdatePoCommand extends WP_CLI_Command {
+	/**
+	 * Update PO files from a POT file.
+	 *
+	 * This behaves similarly to the [msgmerge](https://www.gnu.org/software/gettext/manual/html_node/msgmerge-Invocation.html) command.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <source>
+	 * : Path to an existing POT file to use for updating
+	 *
+	 * [<destination>]
+	 * : PO file to update or a directory containing multiple PO files.
+	 *   Defaults to all PO files in the source directory.
+	 *
+	 * @when before_wp_load
+	 *
+	 * @throws WP_CLI\ExitException
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$source = realpath( $args[0] );
+		if ( ! $source || ! is_file( $source ) ) {
+			WP_CLI::error( 'Source file does not exist!' );
+		}
+
+		$destination = dirname( $source );
+
+		if ( isset( $args[1] ) ) {
+			$destination = $args[1];
+		}
+
+		if ( is_file( $destination ) ) {
+			$files = [ new SplFileInfo( $destination ) ];
+		} else {
+			$files = new IteratorIterator( new DirectoryIterator( $destination ) );
+		}
+
+		$pot_translations = Translations::fromPoFile( $source );
+
+		$result_count = 0;
+		/** @var DirectoryIterator $file */
+		foreach ( $files as $file ) {
+			if ( 'po' !== $file->getExtension() ) {
+				continue;
+			}
+
+			if ( ! $file->isFile() || ! $file->isReadable() ) {
+				WP_CLI::warning( sprintf( 'Could not read file %s', $file->getFilename() ) );
+				continue;
+			}
+
+			$po_translations = Translations::fromPoFile( $file->getPathname() );
+			$po_translations->mergeWith(
+				$pot_translations,
+				Merge::ADD | Merge::REMOVE | Merge::COMMENTS_THEIRS | Merge::EXTRACTED_COMMENTS_THEIRS | Merge::REFERENCES_THEIRS
+			);
+
+			if ( ! $po_translations->toPoFile( $file->getPathname() ) ) {
+				WP_CLI::warning( sprintf( 'Could not update file %s', $file->getPathname() ) );
+				continue;
+			}
+
+			$result_count++;
+		}
+
+		WP_CLI::success( sprintf( 'Updated %d %s.', $result_count, Utils\pluralize( 'file', $result_count ) ) );
+	}
+}


### PR DESCRIPTION
Adds a new `wp i18n update-po` command that works similarly to [msgmerge](https://www.gnu.org/software/gettext/manual/html_node/msgmerge-Invocation.html)

Fixes #278