### PR TITLE
Improve warnings for strings with different comments

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -714,7 +714,7 @@ Feature: Generate a POT file of a WordPress project
       """
     And STDERR should contain:
       """
-      Warning: The string "Hello World" has 2 different translator comments. (foo-plugin.php:7)
+      Warning: The string "Hello World" has 2 different translator comments. (foo-plugin.php:7, foo-plugin.php:10)
       """
 
   Scenario: Does not print a warning when two identical strings have the same translator comment
@@ -932,7 +932,7 @@ Feature: Generate a POT file of a WordPress project
       """
     And STDERR should not contain:
       """
-      Warning: The string "Hello World" has 2 different translator comments. (foo-plugin.php:7)
+      Warning: The string "Hello World" has 2 different translator comments.
       """
 
   Scenario: Skips excluded folders
@@ -3646,7 +3646,7 @@ Feature: Generate a POT file of a WordPress project
         }
       }
       """
-    
+
     When I try `wp i18n make-pot foo-theme`
     Then STDOUT should be:
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -714,7 +714,7 @@ Feature: Generate a POT file of a WordPress project
       """
     And STDERR should contain:
       """
-      Warning: The string "Hello World" has 2 different translator comments. (foo-plugin.php:7, foo-plugin.php:10)
+      Warning: The string "Hello World" has 2 different translator comments. (foo-plugin.php:7)
       translators: Translators 1!
       Translators: Translators 2!
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -715,6 +715,8 @@ Feature: Generate a POT file of a WordPress project
     And STDERR should contain:
       """
       Warning: The string "Hello World" has 2 different translator comments. (foo-plugin.php:7, foo-plugin.php:10)
+      translators: Translators 1!
+      Translators: Translators 2!
       """
 
   Scenario: Does not print a warning when two identical strings have the same translator comment

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -810,10 +810,11 @@ class MakePotCommand extends WP_CLI_Command {
 
 				if ( $comments_count > 1 ) {
 					$message = sprintf(
-						'The string "%1$s" has %2$d different translator comments. %3$s',
+						"The string \"%1\$s\" has %2\$d different translator comments. %3\$s\n%4\$s",
 						$translation->getOriginal(),
 						$comments_count,
-						$all_locations
+						$all_locations,
+						implode( "\n", $unique_comments )
 					);
 					WP_CLI::warning( $message );
 				}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -746,8 +746,10 @@ class MakePotCommand extends WP_CLI_Command {
 		foreach ( $translations as $translation ) {
 			/** @var Translation $translation */
 
+			$references = $translation->getReferences();
+
 			// File headers don't have any file references.
-			$location = $translation->hasReferences() ? '(' . implode( ':', $reference[0] ) . ')' : '';
+			$location = $translation->hasReferences() ? '(' . implode( ':', $references[0] ) . ')' : '';
 
 			// Check 1: Flag strings with placeholders that should have translator comments.
 			if (

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -748,8 +748,13 @@ class MakePotCommand extends WP_CLI_Command {
 
 			$references = $translation->getReferences();
 
+			$reference_to_string = static function( $reference ) {
+				return implode( ':', $reference );
+			};
+
 			// File headers don't have any file references.
-			$location = $translation->hasReferences() ? '(' . implode( ':', array_shift( $references ) ) . ')' : '';
+			$location = $translation->hasReferences() ? '(' . $reference_to_string( $references[0] ) . ')' : '';
+			$all_locations = $translation->hasReferences() ? '(' . implode( ', ', array_map( $reference_to_string, $references ) ) . ')' : '';
 
 			// Check 1: Flag strings with placeholders that should have translator comments.
 			if (
@@ -808,7 +813,7 @@ class MakePotCommand extends WP_CLI_Command {
 						'The string "%1$s" has %2$d different translator comments. %3$s',
 						$translation->getOriginal(),
 						$comments_count,
-						$location
+						$all_locations
 					);
 					WP_CLI::warning( $message );
 				}

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -753,8 +753,7 @@ class MakePotCommand extends WP_CLI_Command {
 			};
 
 			// File headers don't have any file references.
-			$location      = $translation->hasReferences() ? '(' . $reference_to_string( $references[0] ) . ')' : '';
-			$all_locations = $translation->hasReferences() ? '(' . implode( ', ', array_map( $reference_to_string, $references ) ) . ')' : '';
+			$location      = $translation->hasReferences() ? '(' . implode( ':', $reference[0] ) . ')' : '';
 
 			// Check 1: Flag strings with placeholders that should have translator comments.
 			if (
@@ -813,7 +812,7 @@ class MakePotCommand extends WP_CLI_Command {
 						"The string \"%1\$s\" has %2\$d different translator comments. %3\$s\n%4\$s",
 						$translation->getOriginal(),
 						$comments_count,
-						$all_locations,
+						$location,
 						implode( "\n", $unique_comments )
 					);
 					WP_CLI::warning( $message );

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -753,7 +753,7 @@ class MakePotCommand extends WP_CLI_Command {
 			};
 
 			// File headers don't have any file references.
-			$location = $translation->hasReferences() ? '(' . $reference_to_string( $references[0] ) . ')' : '';
+			$location      = $translation->hasReferences() ? '(' . $reference_to_string( $references[0] ) . ')' : '';
 			$all_locations = $translation->hasReferences() ? '(' . implode( ', ', array_map( $reference_to_string, $references ) ) . ')' : '';
 
 			// Check 1: Flag strings with placeholders that should have translator comments.

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -746,14 +746,8 @@ class MakePotCommand extends WP_CLI_Command {
 		foreach ( $translations as $translation ) {
 			/** @var Translation $translation */
 
-			$references = $translation->getReferences();
-
-			$reference_to_string = static function( $reference ) {
-				return implode( ':', $reference );
-			};
-
 			// File headers don't have any file references.
-			$location      = $translation->hasReferences() ? '(' . implode( ':', $reference[0] ) . ')' : '';
+			$location = $translation->hasReferences() ? '(' . implode( ':', $reference[0] ) . ')' : '';
 
 			// Check 1: Flag strings with placeholders that should have translator comments.
 			if (


### PR DESCRIPTION
Lists all different comments attached to the string after the warning.

Example output:

```
$ wp i18n make-pot foo-plugin
Plugin file detected.
Warning: The string "Hello World" has 2 different translator comments. (foo-plugin.php:7)
translators: Translators 1!
Translators: Translators 2!
Success: POT file successfully generated!
```

Fixes #227