### PR TITLE
PHP 8.2: fix "Using ${var} in strings is deprecated, use {$var} instead"

### DIFF
--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -356,7 +356,7 @@ class MakeJsonCommand extends WP_CLI_Command {
 			/** @var Translations $translations */
 
 			$hash             = md5( $file );
-			$destination_file = "${destination}/{$base_file_name}-{$hash}.json";
+			$destination_file = "{$destination}/{$base_file_name}-{$hash}.json";
 
 			$success = JedGenerator::toFile(
 				$translations,


### PR DESCRIPTION
PHP 8.2 deprecated using ${var} in strings
(https://kinsta.com/blog/php-8-2/#deprecate--string-interpolation). {$var} should be used instead. This commit fixes the single occurrence of ${var} in this package located in src/MakeJsonCommand.php.