### PR TITLE
Add `wp i18n make-php` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,32 @@ wp i18n make-mo <source> [<destination>]
 
 
 
+### wp i18n make-php
+
+Create PHP files from PO files.
+
+~~~
+wp i18n make-php <source> [<destination>]
+~~~
+
+**OPTIONS**
+
+	<source>
+		Path to an existing PO file or a directory containing multiple PO files.
+
+	[<destination>]
+		Path to the destination directory for the resulting PHP files. Defaults to the source directory.
+
+**EXAMPLES**
+
+    # Create PHP files for all MO files in the current directory.
+    $ wp i18n make-php .
+
+    # Create a PHP file from a single PO file in a specific directory.
+    $ wp i18n make-php example-plugin-de_DE.po languages
+
+
+
 ### wp i18n update-po
 
 Update PO files from a POT file.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ wp i18n make-php <source> [<destination>]
 
 **EXAMPLES**
 
-    # Create PHP files for all MO files in the current directory.
+    # Create PHP files for all PO files in the current directory.
     $ wp i18n make-php .
 
     # Create a PHP file from a single PO file in a specific directory.

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
             "i18n make-pot",
             "i18n make-json",
             "i18n make-mo",
+            "i18n make-php",
             "i18n update-po"
         ]
     },

--- a/features/makejson.feature
+++ b/features/makejson.feature
@@ -7,7 +7,7 @@ Feature: Split PO files into JSON files.
     When I try `wp i18n make-json foo`
     Then STDERR should contain:
       """
-      Error: Source file or directory does not exist!
+      Error: Source file or directory does not exist.
       """
     And the return code should be 1
 

--- a/features/makemo.feature
+++ b/features/makemo.feature
@@ -7,7 +7,7 @@ Feature: Generate MO files from PO files
     When I try `wp i18n make-mo foo`
     Then STDERR should contain:
       """
-      Error: Source file or directory does not exist!
+      Error: Source file or directory does not exist.
       """
     And the return code should be 1
   Scenario: Bail for destination being a file when source is a folder
@@ -18,7 +18,7 @@ Feature: Generate MO files from PO files
     When I try `wp i18n make-mo foo test.mo `
     Then STDERR should contain:
       """
-      Error: Destination file not supported when source is a directory!
+      Error: Destination file not supported when source is a directory.
       """
     And the return code should be 1
   Scenario: Uses source folder as destination by default

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -126,7 +126,7 @@ Feature: Generate PHP files from PO files
       """
     And the foo-plugin/foo-plugin-de_DE.php file should contain:
       """
-      'messages'=>[''=>['Foo Plugin'=>[0=>'Foo Plugin']]]
+      'messages'=>[''=>['Foo Plugin'=>['Foo Plugin']]]
       """
 
   Scenario: Does include translations
@@ -163,5 +163,5 @@ Feature: Generate PHP files from PO files
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE.php file should contain:
       """
-      'messages'=>[''=>['Foo Plugin'=>[0=>'Bar Plugin']]]
+      'messages'=>[''=>['Foo Plugin'=>['Bar Plugin']]]
       """

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -1,0 +1,158 @@
+Feature: Generate PHP files from PO files
+
+  Background:
+    Given an empty directory
+
+  Scenario: Bail for invalid source directories
+    When I try `wp i18n make-php foo`
+    Then STDERR should contain:
+      """
+      Error: Source file or directory does not exist!
+      """
+    And the return code should be 1
+
+  Scenario: Uses source folder as destination by default
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Foo Plugin"
+      """
+
+    When I run `wp i18n make-php foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.php file should exist
+
+  Scenario: Allows setting custom destination directory
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Foo Plugin"
+      """
+
+    When I run `wp i18n make-php foo-plugin result`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the result/foo-plugin-de_DE.php file should exist
+
+  Scenario: Does include headers
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Foo Plugin"
+      """
+
+    When I run `wp i18n make-php foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+      """
+      Language: de_DE
+      """
+    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+      """
+      X-Domain: foo-plugin
+      """
+
+  Scenario: Does include translations
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Bar Plugin"
+      """
+
+    When I run `wp i18n make-php foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+      """
+      Bar Plugin
+      """

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -111,9 +111,10 @@ Feature: Generate PHP files from PO files
       Success: Created 1 file.
       """
     And the return code should be 0
+    And STDERR should be empty
     And the foo-plugin/foo-plugin-de_DE.php file should contain:
       """
-      'language'=>'de_DE',
+      'language'=>'de_DE'
       """
     And the foo-plugin/foo-plugin-de_DE.php file should contain:
       """
@@ -121,7 +122,11 @@ Feature: Generate PHP files from PO files
       """
     And the foo-plugin/foo-plugin-de_DE.php file should contain:
       """
-      'plural-forms'=>'nplurals=2; plural=(n != 1)'
+      'plural-forms'=>'nplurals=2; plural=(n != 1);'
+      """
+    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+      """
+      'messages'=>[''=>['Foo Plugin'=>[0=>'Foo Plugin']]]
       """
 
   Scenario: Does include translations
@@ -158,5 +163,5 @@ Feature: Generate PHP files from PO files
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE.php file should contain:
       """
-      Bar Plugin
+      'messages'=>[''=>['Foo Plugin'=>[0=>'Bar Plugin']]]
       """

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -43,7 +43,7 @@ Feature: Generate PHP files from PO files
       Success: Created 1 file.
       """
     And the return code should be 0
-    And the foo-plugin/foo-plugin-de_DE.php file should exist
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should exist
 
   Scenario: Allows setting custom destination directory
     Given an empty foo-plugin directory
@@ -77,7 +77,7 @@ Feature: Generate PHP files from PO files
       Success: Created 1 file.
       """
     And the return code should be 0
-    And the result/foo-plugin-de_DE.php file should exist
+    And the result/foo-plugin-de_DE.l10n.php file should exist
 
   Scenario: Does include headers
     Given an empty foo-plugin directory
@@ -112,19 +112,19 @@ Feature: Generate PHP files from PO files
       """
     And the return code should be 0
     And STDERR should be empty
-    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
       'language'=>'de_DE'
       """
-    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
       'domain'=>'foo-plugin'
       """
-    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
       'plural-forms'=>'nplurals=2; plural=(n != 1);'
       """
-    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
       'messages'=>[''=>['Foo Plugin'=>['Foo Plugin']]]
       """
@@ -161,7 +161,7 @@ Feature: Generate PHP files from PO files
       Success: Created 1 file.
       """
     And the return code should be 0
-    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
       'messages'=>[''=>['Foo Plugin'=>['Bar Plugin']]]
       """

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -113,11 +113,15 @@ Feature: Generate PHP files from PO files
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE.php file should contain:
       """
-      Language: de_DE
+      'language'=>'de_DE',
       """
     And the foo-plugin/foo-plugin-de_DE.php file should contain:
       """
-      X-Domain: foo-plugin
+      'domain'=>'foo-plugin'
+      """
+    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+      """
+      'plural-forms'=>'nplurals=2; plural=(n != 1)'
       """
 
   Scenario: Does include translations

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -7,7 +7,7 @@ Feature: Generate PHP files from PO files
     When I try `wp i18n make-php foo`
     Then STDERR should contain:
       """
-      Error: Source file or directory does not exist!
+      Error: Source file or directory does not exist.
       """
     And the return code should be 1
 

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -7,7 +7,7 @@ Feature: Generate a POT file of a WordPress project
     When I try `wp i18n make-pot foo bar/baz.pot`
     Then STDERR should contain:
       """
-      Error: Not a valid source directory!
+      Error: Not a valid source directory.
       """
     And the return code should be 1
 
@@ -20,7 +20,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
@@ -35,7 +35,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
@@ -296,7 +296,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the foo-plugin/languages/foo-plugin.pot file should exist
@@ -328,7 +328,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the foo-plugin.pot file should exist
@@ -388,7 +388,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -595,7 +595,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -659,7 +659,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -681,7 +681,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Theme stylesheet detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the wp-content/themes/foobar/languages/foobar.pot file should exist
@@ -722,7 +722,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -751,7 +751,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should not contain:
       """
@@ -780,7 +780,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should not contain:
       """
@@ -808,7 +808,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -832,7 +832,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -859,7 +859,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -887,7 +887,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -915,7 +915,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -942,7 +942,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should not contain:
       """
@@ -978,7 +978,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -1523,7 +1523,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
@@ -1594,7 +1594,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
@@ -1650,7 +1650,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
@@ -1703,7 +1703,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the wp-content/plugins/hello-world/languages/hello-world.pot file should exist
@@ -1821,7 +1821,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -1949,7 +1949,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -1983,7 +1983,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -2056,7 +2056,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -2146,7 +2146,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -2241,7 +2241,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin.pot file should contain:
       """
@@ -2281,7 +2281,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -2318,7 +2318,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -2352,7 +2352,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin.pot file should contain:
       """
@@ -2383,7 +2383,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin.pot file should contain:
       """
@@ -2418,7 +2418,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin.pot file should contain:
       """
@@ -2472,7 +2472,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the foo-plugin.pot file should contain:
@@ -2532,7 +2532,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the foo-plugin.pot file should contain:
@@ -2580,7 +2580,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -2611,7 +2611,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -2622,7 +2622,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -2650,7 +2650,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Theme stylesheet detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -2699,7 +2699,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Theme stylesheet detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
 
@@ -2763,7 +2763,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the foo-plugin.pot file should contain:
@@ -2854,7 +2854,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should be empty
     And the foo-plugin.pot file should contain:
@@ -2906,7 +2906,7 @@ Feature: Generate a POT file of a WordPress project
     When I try `wp i18n make-pot example-project result.pot --ignore-domain --debug`
     Then STDOUT should be:
       """
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And STDERR should contain:
       """
@@ -2967,7 +2967,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Theme stylesheet detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the result.pot file should contain:
       """
@@ -3024,7 +3024,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Theme stylesheet detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the result.pot file should contain:
       """
@@ -3047,7 +3047,7 @@ Feature: Generate a POT file of a WordPress project
     When I run `wp i18n make-pot example-project result.pot --ignore-domain --package-name="Acme 1.2.3"`
     Then STDOUT should be:
       """
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the result.pot file should contain:
       """
@@ -3070,7 +3070,7 @@ Feature: Generate a POT file of a WordPress project
     When I run `wp i18n make-pot example-project result.pot --ignore-domain --file-comment="Copyright (C) 2018 John Doe\nPowered by WP-CLI."`
     Then STDOUT should be:
       """
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the result.pot file should contain:
        """
@@ -3104,7 +3104,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the contents of the result.pot file should match /^msgid/
 
@@ -3157,7 +3157,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -3283,7 +3283,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -3348,7 +3348,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -3453,7 +3453,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -3538,7 +3538,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Plugin file detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-plugin/foo-plugin.pot file should exist
     And the foo-plugin/foo-plugin.pot file should contain:
@@ -3573,7 +3573,7 @@ Feature: Generate a POT file of a WordPress project
     When I try `wp i18n make-pot foo-theme --skip-theme-json`
     Then STDOUT should be:
       """
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-theme/foo-theme.pot file should exist
     But the foo-theme/foo-theme.pot file should not contain:
@@ -3614,7 +3614,7 @@ Feature: Generate a POT file of a WordPress project
     When I try `wp i18n make-pot foo-theme`
     Then STDOUT should be:
       """
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-theme/foo-theme.pot file should exist
     And the foo-theme/foo-theme.pot file should contain:
@@ -3671,7 +3671,7 @@ Feature: Generate a POT file of a WordPress project
     When I try `wp i18n make-pot foo-theme`
     Then STDOUT should be:
       """
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-theme/foo-theme.pot file should exist
     And the foo-theme/foo-theme.pot file should contain:
@@ -3720,7 +3720,7 @@ Feature: Generate a POT file of a WordPress project
     When I try `wp i18n make-pot foo-theme`
     Then STDOUT should be:
       """
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-theme/foo-theme.pot file should exist
     And the foo-theme/foo-theme.pot file should contain:
@@ -3762,7 +3762,7 @@ Feature: Generate a POT file of a WordPress project
     Then STDOUT should be:
       """
       Theme stylesheet detected.
-      Success: POT file successfully generated!
+      Success: POT file successfully generated.
       """
     And the foo-theme/foo-theme.pot file should exist
     And the foo-theme/foo-theme.pot file should contain:

--- a/features/updatepo.feature
+++ b/features/updatepo.feature
@@ -7,7 +7,7 @@ Feature: Update existing PO files from a POT file
     When I try `wp i18n update-po bar/baz.pot`
     Then STDERR should contain:
       """
-      Error: Source file does not exist!
+      Error: Source file does not exist.
       """
     And the return code should be 1
 
@@ -385,6 +385,6 @@ Feature: Update existing PO files from a POT file
     When I try `wp i18n update-po foo-plugin/foo-plugin.pot foo-plugin/test`
     Then STDERR should contain:
       """
-      Error: Destination file/folder does not exist!
+      Error: Destination file/folder does not exist.
       """
     And the return code should be 1

--- a/i18n-command.php
+++ b/i18n-command.php
@@ -30,4 +30,6 @@ WP_CLI::add_command( 'i18n make-json', '\WP_CLI\I18n\MakeJsonCommand' );
 
 WP_CLI::add_command( 'i18n make-mo', '\WP_CLI\I18n\MakeMoCommand' );
 
+WP_CLI::add_command( 'i18n make-php', '\WP_CLI\I18n\MakePhpCommand' );
+
 WP_CLI::add_command( 'i18n update-po', '\WP_CLI\I18n\UpdatePoCommand' );

--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -86,7 +86,7 @@ class MakeJsonCommand extends WP_CLI_Command {
 		$source = realpath( $args[0] );
 
 		if ( ! $source || ( ! is_file( $source ) && ! is_dir( $source ) ) ) {
-			WP_CLI::error( 'Source file or directory does not exist!' );
+			WP_CLI::error( 'Source file or directory does not exist.' );
 		}
 
 		$destination = is_file( $source ) ? dirname( $source ) : $source;
@@ -100,12 +100,8 @@ class MakeJsonCommand extends WP_CLI_Command {
 			WP_CLI::error( 'No valid keys found. No file was created.' );
 		}
 
-		// Two is_dir() checks in case of a race condition.
-		if ( ! is_dir( $destination )
-			&& ! mkdir( $destination, 0777, true )
-			&& ! is_dir( $destination )
-		) {
-			WP_CLI::error( 'Could not create destination directory!' );
+		if ( ! is_dir( $destination ) && ! mkdir( $destination, 0777, true ) ) {
+			WP_CLI::error( 'Could not create destination directory.' );
 		}
 
 		$result_count = 0;

--- a/src/MakeMoCommand.php
+++ b/src/MakeMoCommand.php
@@ -40,7 +40,7 @@ class MakeMoCommand extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$source = realpath( $args[0] );
 		if ( ! $source || ( ! is_file( $source ) && ! is_dir( $source ) ) ) {
-			WP_CLI::error( 'Source file or directory does not exist!' );
+			WP_CLI::error( 'Source file or directory does not exist.' );
 		}
 
 		$destination      = is_file( $source ) ? dirname( $source ) : $source;
@@ -51,19 +51,15 @@ class MakeMoCommand extends WP_CLI_Command {
 			// Destination is a file, make sure source is also a file
 			if ( ! empty( $destination_pathinfo['filename'] ) && ! empty( $destination_pathinfo['extension'] ) ) {
 				if ( ! is_file( $source ) ) {
-					WP_CLI::error( 'Destination file not supported when source is a directory!' );
+					WP_CLI::error( 'Destination file not supported when source is a directory.' );
 				}
 				$destination      = $destination_pathinfo['dirname'];
 				$custom_file_name = $destination_pathinfo['filename'] . '.' . $destination_pathinfo['extension'];
 			}
 		}
 
-		// Two is_dir() checks in case of a race condition.
-		if ( ! is_dir( $destination )
-			&& ! mkdir( $destination, 0777, true )
-			&& ! is_dir( $destination )
-		) {
-			WP_CLI::error( 'Could not create destination directory!' );
+		if ( ! is_dir( $destination ) && ! mkdir( $destination, 0777, true ) ) {
+			WP_CLI::error( 'Could not create destination directory.' );
 		}
 
 		if ( is_file( $source ) ) {

--- a/src/MakePhpCommand.php
+++ b/src/MakePhpCommand.php
@@ -26,9 +26,11 @@ class MakePhpCommand extends WP_CLI_Command {
 	 *
 	 *     # Create PHP files for all PO files in the current directory.
 	 *     $ wp i18n make-php .
+	 *     Success: Created 3 files.
 	 *
 	 *     # Create a PHP file from a single PO file in a specific directory.
 	 *     $ wp i18n make-php example-plugin-de_DE.po languages
+	 *     Success: Created 1 file.
 	 *
 	 * @when before_wp_load
 	 *
@@ -37,7 +39,7 @@ class MakePhpCommand extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$source = realpath( $args[0] );
 		if ( ! $source || ( ! is_file( $source ) && ! is_dir( $source ) ) ) {
-			WP_CLI::error( 'Source file or directory does not exist!' );
+			WP_CLI::error( 'Source file or directory does not exist.' );
 		}
 
 		$destination = is_file( $source ) ? dirname( $source ) : $source;
@@ -45,12 +47,8 @@ class MakePhpCommand extends WP_CLI_Command {
 			$destination = $args[1];
 		}
 
-		// Two is_dir() checks in case of a race condition.
-		if ( ! is_dir( $destination )
-			&& ! mkdir( $destination, 0777, true )
-			&& ! is_dir( $destination )
-		) {
-			WP_CLI::error( 'Could not create destination directory!' );
+		if ( ! is_dir( $destination ) && ! mkdir( $destination, 0777, true ) ) {
+			WP_CLI::error( 'Could not create destination directory.' );
 		}
 
 		if ( is_file( $source ) ) {

--- a/src/MakePhpCommand.php
+++ b/src/MakePhpCommand.php
@@ -24,7 +24,7 @@ class MakePhpCommand extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Create PHP files for all MO files in the current directory.
+	 *     # Create PHP files for all PO files in the current directory.
 	 *     $ wp i18n make-php .
 	 *
 	 *     # Create a PHP file from a single PO file in a specific directory.

--- a/src/MakePhpCommand.php
+++ b/src/MakePhpCommand.php
@@ -70,7 +70,7 @@ class MakePhpCommand extends WP_CLI_Command {
 			}
 
 			$file_basename    = basename( $file->getFilename(), '.po' );
-			$destination_file = "{$destination}/{$file_basename}.php";
+			$destination_file = "{$destination}/{$file_basename}.l10n.php";
 
 			$translations = Translations::fromPoFile( $file->getPathname() );
 			if ( ! PhpArrayGenerator::toFile( $translations, $destination_file ) ) {

--- a/src/MakePhpCommand.php
+++ b/src/MakePhpCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace WP_CLI\I18n;
+
+use DirectoryIterator;
+use Gettext\Translations;
+use IteratorIterator;
+use SplFileInfo;
+use WP_CLI;
+use WP_CLI\Utils;
+use WP_CLI_Command;
+
+class MakePhpCommand extends WP_CLI_Command {
+	/**
+	 * Create PHP files from PO files.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <source>
+	 * : Path to an existing PO file or a directory containing multiple PO files.
+	 *
+	 * [<destination>]
+	 * : Path to the destination directory for the resulting PHP files. Defaults to the source directory.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Create PHP files for all MO files in the current directory.
+	 *     $ wp i18n make-php .
+	 *
+	 *     # Create a PHP file from a single PO file in a specific directory.
+	 *     $ wp i18n make-php example-plugin-de_DE.po languages
+	 *
+	 * @when before_wp_load
+	 *
+	 * @throws WP_CLI\ExitException
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$source = realpath( $args[0] );
+		if ( ! $source || ( ! is_file( $source ) && ! is_dir( $source ) ) ) {
+			WP_CLI::error( 'Source file or directory does not exist!' );
+		}
+
+		$destination = is_file( $source ) ? dirname( $source ) : $source;
+		if ( isset( $args[1] ) ) {
+			$destination = $args[1];
+		}
+
+		// Two is_dir() checks in case of a race condition.
+		if ( ! is_dir( $destination )
+			&& ! mkdir( $destination, 0777, true )
+			&& ! is_dir( $destination )
+		) {
+			WP_CLI::error( 'Could not create destination directory!' );
+		}
+
+		if ( is_file( $source ) ) {
+			$files = [ new SplFileInfo( $source ) ];
+		} else {
+			$files = new IteratorIterator( new DirectoryIterator( $source ) );
+		}
+
+		$result_count = 0;
+		/** @var DirectoryIterator $file */
+		foreach ( $files as $file ) {
+			if ( 'po' !== $file->getExtension() ) {
+				continue;
+			}
+
+			if ( ! $file->isFile() || ! $file->isReadable() ) {
+				WP_CLI::warning( sprintf( 'Could not read file %s', $file->getFilename() ) );
+				continue;
+			}
+
+			$file_basename    = basename( $file->getFilename(), '.po' );
+			$destination_file = "{$destination}/{$file_basename}.php";
+
+			$translations = Translations::fromPoFile( $file->getPathname() );
+			if ( ! PhpArrayGenerator::toFile( $translations, $destination_file ) ) {
+				WP_CLI::warning( sprintf( 'Could not create file %s', $destination_file ) );
+				continue;
+			}
+
+			$result_count++;
+		}
+
+		WP_CLI::success( sprintf( 'Created %d %s.', $result_count, Utils\pluralize( 'file', $result_count ) ) );
+	}
+}

--- a/src/MakePhpCommand.php
+++ b/src/MakePhpCommand.php
@@ -80,7 +80,7 @@ class MakePhpCommand extends WP_CLI_Command {
 				continue;
 			}
 
-			$result_count++;
+			++$result_count;
 		}
 
 		WP_CLI::success( sprintf( 'Created %d %s.', $result_count, Utils\pluralize( 'file', $result_count ) ) );

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -371,7 +371,7 @@ class MakePotCommand extends WP_CLI_Command {
 
 		WP_CLI::debug( sprintf( 'Destination: %s', $this->destination ), 'make-pot' );
 
-		if ( ! is_dir( $this->destination ) && ! mkdir( $this->destination, 0777, true ) ) {
+		if ( ! is_dir( dirname( $this->destination ) ) && ! mkdir( dirname( $this->destination ), 0777, true ) ) {
 			WP_CLI::error( 'Could not create destination directory.' );
 		}
 

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -297,10 +297,10 @@ class MakePotCommand extends WP_CLI_Command {
 		}
 
 		if ( ! PotGenerator::toFile( $translations, $this->destination ) ) {
-			WP_CLI::error( 'Could not generate a POT file!' );
+			WP_CLI::error( 'Could not generate a POT file.' );
 		}
 
-		WP_CLI::success( 'POT file successfully generated!' );
+		WP_CLI::success( 'POT file successfully generated.' );
 	}
 
 	/**
@@ -331,7 +331,7 @@ class MakePotCommand extends WP_CLI_Command {
 		$ignore_domain = Utils\get_flag_value( $assoc_args, 'ignore-domain', false );
 
 		if ( ! $this->source || ! is_dir( $this->source ) ) {
-			WP_CLI::error( 'Not a valid source directory!' );
+			WP_CLI::error( 'Not a valid source directory.' );
 		}
 
 		$this->main_file_data = $this->get_main_file_data();
@@ -371,12 +371,8 @@ class MakePotCommand extends WP_CLI_Command {
 
 		WP_CLI::debug( sprintf( 'Destination: %s', $this->destination ), 'make-pot' );
 
-		// Two is_dir() checks in case of a race condition.
-		if ( ! is_dir( dirname( $this->destination ) )
-			&& ! mkdir( dirname( $this->destination ), 0777, true )
-			&& ! is_dir( dirname( $this->destination ) )
-		) {
-			WP_CLI::error( 'Could not create destination directory!' );
+		if ( ! is_dir( $this->destination ) && ! mkdir( $this->destination, 0777, true ) ) {
+			WP_CLI::error( 'Could not create destination directory.' );
 		}
 
 		if ( isset( $assoc_args['merge'] ) ) {

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -50,20 +50,20 @@ class PhpArrayGenerator extends PhpArray {
 	 * @return string|void The variable representation or void.
 	 */
 	public static function var_export( $value, $return_only = false ) {
-		if ( is_array( $value ) ) {
-			$entries = array();
-			foreach ( $value as $key => $val ) {
-				$entries[] = var_export( $key, true ) . '=>' . static::var_export( $val, true );
-			}
-
-			$code = '[' . implode( ',', $entries ) . ']';
-			if ( $return_only ) {
-				return $code;
-			}
-
-			echo $code;
-		} else {
+		if ( ! is_array( $value ) ) {
 			return var_export( $value, $return_only );
 		}
+
+		$entries = array();
+		foreach ( $value as $key => $val ) {
+			$entries[] = var_export( $key, true ) . '=>' . static::var_export( $val, true );
+		}
+
+		$code = '[' . implode( ',', $entries ) . ']';
+		if ( $return_only ) {
+			return $code;
+		}
+
+		echo $code;
 	}
 }

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -33,7 +33,7 @@ class PhpArrayGenerator extends PhpArray {
 				continue;
 			}
 
-			$array[ $headers[ $name] ] = $value;
+			$array[ $headers[ $name ] ] = $value;
 		}
 
 		return '<?php' . PHP_EOL . 'return ' . static::var_export( $array, true ) . ';';

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -27,7 +27,7 @@ class PhpArrayGenerator extends PhpArray {
 		}
 
 		$headers = [
-			'X-Generator'  => 'x-generator',
+			'X-Generator' => 'x-generator',
 		];
 
 		foreach ( $translations->getHeaders() as $name => $value ) {

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -18,12 +18,25 @@ class PhpArrayGenerator extends PhpArray {
 	/**
 	 * {@inheritdoc}
 	 */
-	public static function toString(Translations $translations, array $options = []) {
-		$array = static::generate($translations, $options);
+	public static function toString( Translations $translations, array $options = [] ) {
+		$array = static::generate( $translations, $options );
 
-		// TODO: Manually add certain headers like generator to $array.
+		$headers = [
+			'Plural-Forms' => 'plural-forms',
+			'X-Generator'  => 'generator',
+			'X-Domain'     => 'domain',
+			'Language'     => 'language',
+		];
 
-		return '<?php' . PHP_EOL . 'return ' . static::var_export( $array, true ) .';';
+		foreach ( $translations->getHeaders() as $name => $value ) {
+			if ( ! isset( $headers[ $name ] ) ) {
+				continue;
+			}
+
+			$array[ $headers[ $name] ] = $value;
+		}
+
+		return '<?php' . PHP_EOL . 'return ' . static::var_export( $array, true ) . ';';
 	}
 
 	/**

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace WP_CLI\I18n;
+
+use Gettext\Generators\PhpArray;
+use Gettext\Translations;
+
+/**
+ * PHP array file generator.
+ *
+ * Returns output in the form WordPress uses.
+ */
+class PhpArrayGenerator extends PhpArray {
+	public static $options = [
+		'includeHeaders' => false,
+	];
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function toString(Translations $translations, array $options = []) {
+		$array = static::generate($translations, $options);
+
+		// TODO: Manually add certain headers like generator to $array.
+
+		return '<?php' . PHP_EOL . 'return ' . static::var_export( $array, true ) .';';
+	}
+
+	/**
+	 * Outputs or returns a parsable string representation of a variable.
+	 *
+	 * Like {@see var_export()} but "minified", using short array syntax
+	 * and no newlines.
+	 *
+	 * @param mixed $value       The variable you want to export.
+	 * @param bool  $return_only Optional. Whether to return the variable representation instead of outputing it. Default false.
+	 * @return string|void The variable representation or void.
+	 */
+	public static function var_export( $value, $return_only = false ) {
+		if ( is_array( $value ) ) {
+			$entries = array();
+			foreach ( $value as $key => $val ) {
+				$entries[] = var_export( $key, true ) . '=>' . static::var_export( $val, true );
+			}
+
+			$code = '[' . implode( ',', $entries ) . ']';
+			if ( $return_only ) {
+				return $code;
+			}
+
+			echo $code;
+		} else {
+			return var_export( $value, $return_only );
+		}
+	}
+}

--- a/src/UpdatePoCommand.php
+++ b/src/UpdatePoCommand.php
@@ -34,7 +34,7 @@ class UpdatePoCommand extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$source = realpath( $args[0] );
 		if ( ! $source || ! is_file( $source ) ) {
-			WP_CLI::error( 'Source file does not exist!' );
+			WP_CLI::error( 'Source file does not exist.' );
 		}
 
 		$destination = dirname( $source );
@@ -44,7 +44,7 @@ class UpdatePoCommand extends WP_CLI_Command {
 		}
 
 		if ( ! file_exists( $destination ) ) {
-			WP_CLI::error( 'Destination file/folder does not exist!' );
+			WP_CLI::error( 'Destination file/folder does not exist.' );
 		}
 
 		if ( is_file( $destination ) ) {


### PR DESCRIPTION
The WordPress core performance team is working on the Performant Translations feature project, which aims to speed up translations by using PHP files instead of MO files. The goal is to get it ready for WordPress 6.5.

While the idea is to have translate.wordpress.org ship these PHP files in language packs, some developers might be using WP-CLI for their i18n workflow, especially locally. For them it would be beneficial to be able to quickly generate the necessary translation files.

**Additional Context**

* https://make.wordpress.org/core/2023/09/05/call-for-testing-performant-translations/
* https://wordpress.org/plugins/performant-translations/
* https://github.com/swissspidy/performant-translations
* https://github.com/WordPress/wordpress-develop/pull/5306
* https://github.com/GlotPress/GlotPress/pull/1626

