### PR TITLE
make-pot: Add TypeScript support

### DIFF
--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -657,7 +657,7 @@ class MakePotCommand extends WP_CLI_Command {
 					[
 						'include'       => $this->include,
 						'exclude'       => $this->exclude,
-						'extensions'    => [ 'js', 'jsx' ],
+						'extensions'    => [ 'js', 'jsx', 'ts', 'tsx' ],
 						'addReferences' => $this->location,
 					]
 				);


### PR DESCRIPTION
This PR updates the `make-pot` command to support scanning files that end with `.ts` and `.tsx` to support TypeScript