### PR TITLE
`make-mo`: Add destination file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ wp i18n make-mo <source> [<destination>]
 		Path to an existing PO file or a directory containing multiple PO files.
 
 	[<destination>]
-		Path to the destination directory for the resulting MO files. Defaults to the source directory.
+		Path to the destination file or directory for the resulting MO files. Defaults to the source directory.
 
 **EXAMPLES**
 
@@ -221,6 +221,9 @@ wp i18n make-mo <source> [<destination>]
 
     # Create a MO file from a single PO file in a specific directory.
     $ wp i18n make-mo example-plugin-de_DE.po languages
+
+    # Create a MO file from a single PO file to a specific file destination
+    $ wp i18n make-mo example-plugin-de_DE.po languages/bar.mo
 
 
 

--- a/features/makemo.feature
+++ b/features/makemo.feature
@@ -10,7 +10,17 @@ Feature: Generate MO files from PO files
       Error: Source file or directory does not exist!
       """
     And the return code should be 1
-
+  Scenario: Bail for destination being a file when source is a folder
+    Given an empty foo directory
+    And a foo/foo.po file:
+    """
+    """
+    When I try `wp i18n make-mo foo test.mo `
+    Then STDERR should contain:
+      """
+      Error: Destination file not supported when source is a directory!
+      """
+    And the return code should be 1
   Scenario: Uses source folder as destination by default
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin-de_DE.po file:
@@ -44,7 +54,39 @@ Feature: Generate MO files from PO files
       """
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE.mo file should exist
-
+  Scenario: Uses the provided destination file name
+    Given a foo.po file:
+    """
+    """
+    When I run `wp i18n make-mo foo.po bar.mo`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the bar.mo file should exist
+  Scenario: Uses the provided destination file name with no extension
+    Given a foo.po file:
+    """
+    """
+    When I run `wp i18n make-mo foo.po bar`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the bar file should exist
+  Scenario: Preserves the provided source name with no destination
+    Given a foo.po file:
+    """
+    """
+    When I run `wp i18n make-mo foo.po`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo.mo file should exist
   Scenario: Allows setting custom destination directory
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin-de_DE.po file:


### PR DESCRIPTION
Based on the discussion in #372, the `MakeMo `command should support a destination file name.

This PR allows you to specify a destination file name when the source is a file. When the source is a directory, providing a destination file name is not supported:

`wp i18n make-mo foo.po` -> unchanged behavior, writes foo.mo to same directory as foo.po
`wp i18n make-mo foo.po bar.mo` -> writes file to bar.mo
`wp i18n make-mo foo/bar` -> unchanged behavior, generates MO files for all PO files in the directory
`wp i18n make-mo foo/bar baz.mo` -> won't work!