### PR TITLE
Fix file format in make-php

### DIFF
--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -151,8 +151,19 @@ Feature: Generate PHP files from PO files
       "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
       #: foo-plugin.js:15
+      msgctxt "Plugin Name"
+      msgid "Foo Plugin (EN)"
+      msgstr "Foo Plugin (DE)"
+
+      #: foo-plugin.js:15
       msgid "Foo Plugin"
       msgstr "Bar Plugin"
+
+      #: foo-plugin.php:60
+      msgid "You have %d new message"
+      msgid_plural "You have %d new messages"
+      msgstr[0] "Sie haben %d neue Nachricht"
+      msgstr[1] "Sie haben %d neue Nachrichten"
       """
 
     When I run `wp i18n make-php foo-plugin`
@@ -163,5 +174,5 @@ Feature: Generate PHP files from PO files
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
-      'messages'=>[''=>['Foo Plugin'=>['Bar Plugin']]]
+      return ['domain'=>'foo-plugin','plural-forms'=>'nplurals=2; plural=(n != 1);','messages'=>['Plugin NameFoo Plugin (EN)'=>'Foo Plugin (DE)','Foo Plugin'=>'Bar Plugin','You have %d new message'=>'Sie haben %d neue Nachricht' . "\0" . 'Sie haben %d neue Nachrichten'],'language'=>'de_DE'];
       """

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -126,7 +126,7 @@ Feature: Generate PHP files from PO files
       """
     And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
-      'messages'=>[''=>['Foo Plugin'=>['Foo Plugin']]]
+      'messages'=>['Foo Plugin'=>'Foo Plugin']
       """
 
   Scenario: Does include translations

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -64,7 +64,7 @@ class PhpArrayGenerator extends PhpArray {
 	 * @return array
 	 */
 	protected static function toArray( Translations $translations, $include_headers, $force_array = false ) {
-		$messages    = [];
+		$messages = [];
 
 		if ( $include_headers ) {
 			$messages[''] = [


### PR DESCRIPTION
Follow-up to #363. Requirement for WP 6.5 support.

Now that the new format is in core & GlotPress I realized some mistakes in my original implementation.
