### PR TITLE
Add more headers to php translation files

### DIFF
--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -83,26 +83,65 @@ Feature: Generate PHP files from PO files
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin-de_DE.po file:
       """
-      # Copyright (C) 2018 Foo Plugin
-      # This file is distributed under the same license as the Foo Plugin package.
+      # Translation of 5.2.x in German
+      # This file is distributed under the same license as the 5.2.x package.
       msgid ""
       msgstr ""
-      "Project-Id-Version: Foo Plugin\n"
-      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
-      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-      "Language-Team: LANGUAGE <LL@li.org>\n"
-      "Language: de_DE\n"
+      "PO-Revision-Date: 2019-03-28 19:42+0300\n"
       "MIME-Version: 1.0\n"
       "Content-Type: text/plain; charset=UTF-8\n"
       "Content-Transfer-Encoding: 8bit\n"
-      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
-      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
-      "X-Domain: foo-plugin\n"
-      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+      "Plural-Forms: nplurals=2; plural=n != 1;\n"
+      "X-Generator: Poedit 2.2.1\n"
+      "Project-Id-Version: Development (5.2.x)\n"
+      "Language: de_DE\n"
+      "POT-Creation-Date: \n"
+      "Last-Translator: \n"
+      "Language-Team: \n"
 
-      #: foo-plugin.js:15
-      msgid "Foo Plugin"
-      msgstr "Foo Plugin"
+      #. translators: Translate this to the correct language tag for your locale, see
+      #. https://www.w3.org/International/articles/language-tags/ for reference. Do
+      #. not translate into your own language.
+      #: wp-includes/general-template.php:716
+      msgid "html_lang_attribute"
+      msgstr "de-DE"
+
+      #. translators: 'rtl' or 'ltr'. This sets the text direction for WordPress.
+      #: wp-includes/class-wp-locale.php:223
+      msgctxt "text direction"
+      msgid "ltr"
+      msgstr "ltr"
+
+      #. translators: $dec_point argument for https://secure.php.net/number_format,
+      #. default is .
+      #: wp-includes/class-wp-locale.php:215
+      msgid "number_format_decimal_point"
+      msgstr ","
+
+      #. translators: $thousands_sep argument for
+      #. https://secure.php.net/number_format, default is ,
+      #: wp-includes/class-wp-locale.php:202
+      msgid "number_format_thousands_sep"
+      msgstr "."
+
+      #. translators: %s: Plugin name and version
+      #: wp-includes/script-loader.php:620
+      msgid "Update %s now"
+      msgstr "Jetzt %s aktualisieren"
+
+      #. translators: Privacy data request subject. 1: Site name, 2: Name of the action
+      #: wp-includes/user.php:3445
+      msgid "[%1$s] Confirm Action: %2$s"
+      msgstr "[%1$s] Aktion bestätigen: %2$s"
+
+      #. translators: %s: Site name.
+      #: wp-includes/user.php:3175
+      msgid "[%s] Erasure Request Fulfilled"
+      msgstr "[%s] Löschauftrag ausgeführt"
+
+      #: wp-admin/includes/file.php:2415
+      msgid "[%s] Personal Data Export"
+      msgstr "[%s] Export personenbezogener Daten"
       """
 
     When I run `wp i18n make-php foo-plugin`
@@ -114,19 +153,8 @@ Feature: Generate PHP files from PO files
     And STDERR should be empty
     And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
-      'language'=>'de_DE'
-      """
-    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
-      """
-      'domain'=>'foo-plugin'
-      """
-    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
-      """
-      'plural-forms'=>'nplurals=2; plural=(n != 1);'
-      """
-    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
-      """
-      'messages'=>['Foo Plugin'=>'Foo Plugin']
+      <?php
+      return ['domain'=>NULL,'plural-forms'=>'nplurals=2; plural=n != 1;','language'=>'de_DE','project-id-version'=>'Development (5.2.x)','pot-creation-date'=>'','po-revision-date'=>'2019-03-28 19:42+0300','x-generator'=>'Poedit 2.2.1','messages'=>['html_lang_attribute'=>'de-DE','text directionltr'=>'ltr','number_format_decimal_point'=>',','number_format_thousands_sep'=>'.','Update %s now'=>'Jetzt %s aktualisieren','[%1$s] Confirm Action: %2$s'=>'[%1$s] Aktion bestätigen: %2$s','[%s] Erasure Request Fulfilled'=>'[%s] Löschauftrag ausgeführt','[%s] Personal Data Export'=>'[%s] Export personenbezogener Daten']];
       """
 
   Scenario: Does include translations
@@ -174,5 +202,5 @@ Feature: Generate PHP files from PO files
     And the return code should be 0
     And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
-      return ['domain'=>'foo-plugin','plural-forms'=>'nplurals=2; plural=(n != 1);','messages'=>['Plugin NameFoo Plugin (EN)'=>'Foo Plugin (DE)','Foo Plugin'=>'Bar Plugin','You have %d new message'=>'Sie haben %d neue Nachricht' . "\0" . 'Sie haben %d neue Nachrichten'],'language'=>'de_DE'];
+      return ['domain'=>'foo-plugin','plural-forms'=>'nplurals=2; plural=(n != 1);','language'=>'de_DE','project-id-version'=>'Foo Plugin','pot-creation-date'=>'2018-05-02T22:06:24+00:00','po-revision-date'=>'2018-05-02T22:06:24+00:00','messages'=>['Plugin NameFoo Plugin (EN)'=>'Foo Plugin (DE)','Foo Plugin'=>'Bar Plugin','You have %d new message'=>'Sie haben %d neue Nachricht' . "\0" . 'Sie haben %d neue Nachrichten']];
       """


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Besides a little code cleanup this mainly expands the allowlist of headers added to the `.l10n.php` files.

This is relevant for https://github.com/WordPress/wordpress-develop/pull/6129 and the WordPress.org updates API which looks at headers such as `po-revision-date` to see if an update is available.
