### PR TITLE
make-php: skip strings without translation

### DIFF
--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -204,3 +204,58 @@ Feature: Generate PHP files from PO files
       """
       return ['domain'=>'foo-plugin','plural-forms'=>'nplurals=2; plural=(n != 1);','language'=>'de_DE','project-id-version'=>'Foo Plugin','pot-creation-date'=>'2018-05-02T22:06:24+00:00','po-revision-date'=>'2018-05-02T22:06:24+00:00','messages'=>['Plugin NameFoo Plugin (EN)'=>'Foo Plugin (DE)','Foo Plugin'=>'Bar Plugin','You have %d new message'=>'Sie haben %d neue Nachricht' . "\0" . 'Sie haben %d neue Nachrichten']];
       """
+
+  Scenario: Excludes strings without translations
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.php:10
+      msgid "I exist"
+      msgstr "I exist (DE)"
+
+      #: foo-plugin.php:20
+      msgid "I am empty"
+      msgstr ""
+
+      #: foo-plugin.php:30
+      msgid "You have %d new message"
+      msgid_plural "You have %d new messages"
+      msgstr[0] ""
+      msgstr[1] ""
+      """
+
+    When I run `wp i18n make-php foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
+      """
+      I exist
+      """
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should not contain:
+      """
+      I am empty
+      """
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should not contain:
+      """
+      new message
+      """

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -78,7 +78,7 @@ class PhpArrayGenerator extends PhpArray {
 		 * @var Translation $translation
 		 */
 		foreach ( $translations as $translation ) {
-			if ( $translation->isDisabled() ) {
+			if ( $translation->isDisabled() || ! $translation->hasTranslation() ) {
 				continue;
 			}
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Without this, a string without a translation would have an empty string as a translation, which would cause WP to show that empty string instead of the original.

Props @lgladdy 
