### PR TITLE
Add support for pretty-printing PHP files in wp i18n make-php command

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ wp i18n make-php <source> [<destination>]
 	[<destination>]
 		Path to the destination directory for the resulting PHP files. Defaults to the source directory.
 
+	[--pretty-print]
+		Pretty-print resulting PHP files.
+
 **EXAMPLES**
 
     # Create PHP files for all PO files in the current directory.

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -259,3 +259,48 @@ Feature: Generate PHP files from PO files
       """
       new message
       """
+
+  Scenario: Should create pretty-printed PHP files
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.js:15
+      msgid "Foo Plugin"
+      msgstr "Foo Plugin"
+      """
+
+    When I run `wp i18n make-php foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.php file should contain:
+      """
+      <?php
+      return [
+          'project-id-version' => 'Foo Plugin',
+          'report-msgid-bugs-to' => 'https://wordpress.org/support/plugin/foo-plugin',
+          'messages' =>
+              [
+                  'Foo Plugin' => 'Foo Plugin',
+              ],
+      ];
+      """

--- a/src/MakePhpCommand.php
+++ b/src/MakePhpCommand.php
@@ -22,6 +22,9 @@ class MakePhpCommand extends WP_CLI_Command {
 	 * [<destination>]
 	 * : Path to the destination directory for the resulting PHP files. Defaults to the source directory.
 	 *
+	 * [--pretty-print]
+	 * : Pretty-print resulting PHP files.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Create PHP files for all PO files in the current directory.
@@ -58,6 +61,8 @@ class MakePhpCommand extends WP_CLI_Command {
 		}
 
 		$result_count = 0;
+		$pretty_print = Utils\get_flag_value( $assoc_args, 'pretty-print', false );
+
 		/** @var DirectoryIterator $file */
 		foreach ( $files as $file ) {
 			if ( 'po' !== $file->getExtension() ) {
@@ -73,7 +78,7 @@ class MakePhpCommand extends WP_CLI_Command {
 			$destination_file = "{$destination}/{$file_basename}.l10n.php";
 
 			$translations = Translations::fromPoFile( $file->getPathname() );
-			if ( ! PhpArrayGenerator::toFile( $translations, $destination_file ) ) {
+			if ( ! PhpArrayGenerator::toFile( $translations, $destination_file, [ 'prettyPrint' => $pretty_print ] ) ) {
 				WP_CLI::warning( sprintf( 'Could not create file %s', $destination_file ) );
 				continue;
 			}


### PR DESCRIPTION
It should resolve this issue: https://github.com/wp-cli/i18n-command/issues/395