### PR TITLE
Add tests for rspack and esbuild bundle output

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1842,6 +1842,13 @@ Feature: Generate a POT file of a WordPress project
       wp__WEBPACK_IMPORTED_MODULE_5___default().__("rspack.default-import.__", "foo-plugin");
       wp__WEBPACK_IMPORTED_MODULE_5__.__("rspack.default-star-import.__", "foo-plugin");
 
+      var import_wp = __require("wp");
+      var import_wp2 = __toESM(__require("wp"));
+      var wpStarImport = __toESM(__require("wp"));
+      console.log((0, import_wp.__)("esbuild.__", "foo-plugin"));
+      console.log(import_wp2.default.__("esbuild.default-import.__", "foo-plugin"));
+      console.log(wpStarImport.__("esbuild.default-star-import.__", "foo-plugin"));
+
       Object(u.__)( 'minified.__', 'foo-plugin' );
       Object(j._x)( 'minified._x', 'minified._x_context', 'foo-plugin' );
 
@@ -1933,6 +1940,18 @@ Feature: Generate a POT file of a WordPress project
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       msgid "rspack.default-star-import.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "esbuild.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "esbuild.default-import.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "esbuild.default-star-import.__"
       """
     And the foo-plugin/foo-plugin.pot file should contain:
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -1838,6 +1838,10 @@ Feature: Generate a POT file of a WordPress project
       Object(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_7__["__"])( 'webpack.__', 'foo-plugin' );
       Object(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_7__[/* __ */ "a"])( 'webpack.mangle.__', 'foo-plugin' );
 
+      (0,wp__WEBPACK_IMPORTED_MODULE_5__.__)("rspack.__", "foo-plugin");
+      wp__WEBPACK_IMPORTED_MODULE_5___default().__("rspack.default-import.__", "foo-plugin");
+      wp__WEBPACK_IMPORTED_MODULE_5__.__("rspack.default-star-import.__", "foo-plugin");
+
       Object(u.__)( 'minified.__', 'foo-plugin' );
       Object(j._x)( 'minified._x', 'minified._x_context', 'foo-plugin' );
 
@@ -1917,6 +1921,18 @@ Feature: Generate a POT file of a WordPress project
     And the foo-plugin/foo-plugin.pot file should contain:
       """
       msgid "webpack.mangle.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "rspack.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "rspack.default-import.__"
+      """
+    And the foo-plugin/foo-plugin.pot file should contain:
+      """
+      msgid "rspack.default-star-import.__"
       """
     And the foo-plugin/foo-plugin.pot file should contain:
       """


### PR DESCRIPTION
This is a follow-up to https://github.com/wp-cli/i18n-command/issues/203 and https://github.com/wp-cli/i18n-command/pull/204. 

In general, the `wp i18n make-pot` already works with [rspack](https://www.rspack.dev/) and [esbuild](https://esbuild.github.io/getting-started/#your-first-bundle) and can extract the strings correctly from the generated bundle.

This PR just adds test for both bundlers.

Reference. https://github.com/wp-cli/wp-cli/issues/5955