### PR TITLE
theme.json: find `title` string within `styles.blocks.variations`

### DIFF
--- a/assets/theme-i18n.json
+++ b/assets/theme-i18n.json
@@ -73,6 +73,15 @@
 			}
 		}
 	},
+	"styles": {
+		"blocks": {
+			"variations": {
+				"*": {
+					"title": "Style variation name"
+				}
+			}
+		}
+	},
 	"customTemplates": [
 		{
 			"title": "Custom template name"

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3724,7 +3724,7 @@ Feature: Generate a POT file of a WordPress project
     And the foo-theme/foo-theme.pot file should contain:
       """
       msgctxt "Style variation name"
-      msgid "My style variation"
+      msgid "My variation"
       """
 
   Scenario: Extract strings from the blocks section of theme.json files

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3682,6 +3682,51 @@ Feature: Generate a POT file of a WordPress project
       msgid "My style variation"
       """
 
+  Scenario: Extract strings from the styles.blocks.variations section of theme.json files
+    Given an empty foo-theme directory
+    And a foo-theme/theme.json file:
+      """
+      {
+        "version": "1",
+        "settings": {
+          "color": {
+            "duotone": [
+                { "slug": "dark-grayscale", "name": "Dark grayscale", "colors": [] }
+            ],
+          }
+        },
+        "styles": {
+          "blocks": {
+            "variations": {
+              "variationSlug": {
+                "title": "My variation",
+                "color": {
+                  "background": "grey"
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+
+    When I try `wp i18n make-pot foo-theme`
+    Then STDOUT should be:
+      """
+      Success: POT file successfully generated.
+      """
+    And the foo-theme/foo-theme.pot file should exist
+    And the foo-theme/foo-theme.pot file should contain:
+      """
+      msgctxt "Duotone name"
+      msgid "Dark grayscale"
+      """
+    And the foo-theme/foo-theme.pot file should contain:
+      """
+      msgctxt "Style variation name"
+      msgid "My style variation"
+      """
+
   Scenario: Extract strings from the blocks section of theme.json files
     Given an empty foo-theme directory
     And a foo-theme/theme.json file:

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3775,6 +3775,18 @@ Feature: Generate a POT file of a WordPress project
               }
             }
           }
+        },
+        "styles": {
+          "blocks": {
+            "variations": {
+              "myVariation": {
+                "title": "My variation",
+                "color": {
+                  "background": "grey"
+                }
+              }
+            }
+          }
         }
       }
       """
@@ -3789,6 +3801,18 @@ Feature: Generate a POT file of a WordPress project
                 "palette": [
                   { "slug": "white", "color": "#ffffff", "name": "White" }
                 ]
+              }
+            }
+          }
+        },
+        "styles": {
+          "blocks": {
+            "variations": {
+              "otherVariation": {
+                "title": "My other variation",
+                "color": {
+                  "background": "grey"
+                }
               }
             }
           }
@@ -3807,9 +3831,19 @@ Feature: Generate a POT file of a WordPress project
       msgctxt "Color name"
       msgid "Black"
       """
+    And the foo-theme/foo-theme.pot file should contain:
+      """
+      msgctxt "Style variation name"
+      msgid "My variation"
+      """
     And the foo-theme/foo-theme.pot file should not contain:
       """
       msgid "White"
+      """
+    And the foo-theme/foo-theme.pot file should not contain:
+      """
+      msgctxt "Style variation name"
+      msgid "My other variation"
       """
 
   Scenario: Extract strings from the patterns directory

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3692,7 +3692,7 @@ Feature: Generate a POT file of a WordPress project
           "color": {
             "duotone": [
                 { "slug": "dark-grayscale", "name": "Dark grayscale", "colors": [] }
-            ],
+            ]
           }
         },
         "styles": {


### PR DESCRIPTION
Related PRs in this repo: https://github.com/wp-cli/i18n-command/pull/254 https://github.com/wp-cli/i18n-command/pull/292 https://github.com/wp-cli/i18n-command/pull/306
Related Gutenberg PR for this string: https://github.com/WordPress/gutenberg/pull/62552

There's a new feature coming for WordPress 6.6 that allows theme authors to register block style variations through `theme.json`. Block style variations have a label that is displayed to users, so it needs to be translated. I just found out that there is a missing place where the label wasn't picked from. This PR follows suit on what is done in Gutenberg at https://github.com/WordPress/gutenberg/pull/62552 There's an upcoming WordPress core PR as well.

## Setup

- See https://make.wordpress.org/cli/handbook/contributions/pull-requests/#setting-up
- Install and prepare dependencies:

```
brew install jq mysql
brew service start mysql
mysql_secure_installation
sudo mysql -u root -p

# MySQL Session
CREATE DATABASE IF NOT EXISTS `wp_cli_test`;
CREATE USER 'wp_cli_test'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password1';
GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost";
\q
```

## Test

Before running any of the test (manual or automattic), make sure to set the `THEME_JSON_SOURCE` to [empty](https://github.com/wp-cli/i18n-command/blob/ebc79f4172fc69f84716885c3c50cbbc3e8cd293/src/JsonSchemaExtractor.php#L18) so the `ThemeJsonExtractor` picks the the local backup file with the changes at `assets/theme-i18n.json`.

Automated tests:

```sh
composer install
composer behat -- features/makepot.feature
```

Manual testing:

- Check out this PR locally and cd to the directory.
- `composer install`
- Create a new directory called `foo-theme` that contains a `theme.json` file with the following contents:

```json
{
    "styles": {
      "blocks": {
        "variations": {
          "myVariation": {
            "title": "My variation",
            "blockTypes": [ "core/group" ],
            "color": {
              "background": "red"
            }
          }
        }
      }
    }
}
```

- Create a new file called `ember.json` within `foo-theme/styles.json` with the following contents:

```json
{
    "styles": {
      "blocks": {
        "variations": {
          "myVariation": {
            "title": "Other variation",
            "blockTypes": [ "core/group" ],
            "color": {
              "background": "red"
            }
          }
        }
      }
    }
}
```

- Run `vendor/bin/wp i18n make-pot foo-theme`
- Verify that there's a `foo-theme/foo-theme.pot` file and that the two variations labels are present as well as its context "Style variation name". You should see something like:

```
#: styles/ember.json
msgctxt "Style variation name"
msgid "Other variation"
msgstr ""

#: theme.json
msgctxt "Style variation name"
msgid "My variation"
msgstr ""
```

## Comments

This also needs a WordPress core PR. https://github.com/WordPress/gutenberg/pull/62552 will be backported with the necessary changes.
