### PR TITLE
Revert changes to extract title from styles.blocks.variations

### DIFF
--- a/assets/theme-i18n.json
+++ b/assets/theme-i18n.json
@@ -80,15 +80,6 @@
 			}
 		}
 	},
-	"styles": {
-		"blocks": {
-			"variations": {
-				"*": {
-					"title": "Style variation name"
-				}
-			}
-		}
-	},
 	"customTemplates": [
 		{
 			"title": "Custom template name"

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3717,51 +3717,6 @@ Feature: Generate a POT file of a WordPress project
       msgid "My style variation"
       """
 
-  Scenario: Extract strings from the styles.blocks.variations section of theme.json files
-    Given an empty foo-theme directory
-    And a foo-theme/theme.json file:
-      """
-      {
-        "version": "1",
-        "settings": {
-          "color": {
-            "duotone": [
-                { "slug": "dark-grayscale", "name": "Dark grayscale", "colors": [] }
-            ]
-          }
-        },
-        "styles": {
-          "blocks": {
-            "variations": {
-              "variationSlug": {
-                "title": "My variation",
-                "color": {
-                  "background": "grey"
-                }
-              }
-            }
-          }
-        }
-      }
-      """
-
-    When I try `wp i18n make-pot foo-theme`
-    Then STDOUT should be:
-      """
-      Success: POT file successfully generated.
-      """
-    And the foo-theme/foo-theme.pot file should exist
-    And the foo-theme/foo-theme.pot file should contain:
-      """
-      msgctxt "Duotone name"
-      msgid "Dark grayscale"
-      """
-    And the foo-theme/foo-theme.pot file should contain:
-      """
-      msgctxt "Style variation name"
-      msgid "My variation"
-      """
-
   Scenario: Extract strings from the blocks section of theme.json files
     Given an empty foo-theme directory
     And a foo-theme/theme.json file:
@@ -3810,18 +3765,6 @@ Feature: Generate a POT file of a WordPress project
               }
             }
           }
-        },
-        "styles": {
-          "blocks": {
-            "variations": {
-              "myVariation": {
-                "title": "My variation",
-                "color": {
-                  "background": "grey"
-                }
-              }
-            }
-          }
         }
       }
       """
@@ -3836,18 +3779,6 @@ Feature: Generate a POT file of a WordPress project
                 "palette": [
                   { "slug": "white", "color": "#ffffff", "name": "White" }
                 ]
-              }
-            }
-          }
-        },
-        "styles": {
-          "blocks": {
-            "variations": {
-              "otherVariation": {
-                "title": "My other variation",
-                "color": {
-                  "background": "grey"
-                }
               }
             }
           }
@@ -3866,19 +3797,9 @@ Feature: Generate a POT file of a WordPress project
       msgctxt "Color name"
       msgid "Black"
       """
-    And the foo-theme/foo-theme.pot file should contain:
-      """
-      msgctxt "Style variation name"
-      msgid "My variation"
-      """
     And the foo-theme/foo-theme.pot file should not contain:
       """
       msgid "White"
-      """
-    And the foo-theme/foo-theme.pot file should not contain:
-      """
-      msgctxt "Style variation name"
-      msgid "My other variation"
       """
 
   Scenario: Extract strings from the patterns directory


### PR DESCRIPTION
## What

This PR reverts https://github.com/wp-cli/i18n-command/pull/405

## Why

https://github.com/wp-cli/i18n-command/pull/405 introduced the ability to extract strings (`title`) from the property `styles.blocks.variations` of the `theme.json` — these were missing and detected during the beta period.

Later on, the feature [received more feedback](https://github.com/WordPress/gutenberg/issues/62686) and the consensus was to remove the ability to _register_ block style variations from `theme.json`. That together with some changes to the shape of the `styles` subtree, made https://github.com/wp-cli/i18n-command/pull/405 unnecessary, as there is no longer a `title` key to translate.

## How

Revert the changes introduced in #405 

## Test

Automated test should pass. They are now broken in `main`. See setup instructions at https://github.com/wp-cli/i18n-command/pull/405

```sh
composer install
composer behat -- features/makepot.feature
```