### PR TITLE
Translate "description" field from theme.json

### DIFF
--- a/assets/theme-i18n.json
+++ b/assets/theme-i18n.json
@@ -1,5 +1,6 @@
 {
 	"title": "Style variation name",
+	"description": "Style variation description",
 	"settings": {
 		"typography": {
 				"fontSizes": [

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3658,6 +3658,7 @@ Feature: Generate a POT file of a WordPress project
       {
         "version": "1",
         "title": "My style variation",
+        "description": "My style variation description",
         "settings": {
           "color": {
             "duotone": [
@@ -3715,6 +3716,11 @@ Feature: Generate a POT file of a WordPress project
       """
       msgctxt "Style variation name"
       msgid "My style variation"
+      """
+    And the foo-theme/foo-theme.pot file should contain:
+      """
+      msgctxt "Style variation description"
+      msgid "My style variation description"
       """
 
   Scenario: Extract strings from the blocks section of theme.json files


### PR DESCRIPTION

This PR:

- adds a new field "description" to theme.json top level to translate
- updates the expectation to existing behat tests

> [!IMPORTANT]
> A [WordPress Core PR exists](https://github.com/WordPress/wordpress-develop/pull/6947) to add the "description" key to `src/wp-includes/theme-i18n.json`. This has not yet been committed.

## TODO

- [ ] Check test instructions (this is my first PR)
- [ ] Have the [Core PR](https://github.com/WordPress/wordpress-develop/pull/6947) tested and committed

## Context

A "description" key was added to theme.json in https://github.com/WordPress/gutenberg/pull/45242

The Gutenberg PR was synced to Core in https://github.com/WordPress/wordpress-develop/pull/4687

Unfortunately, a corresponding entry to the theme.json i18n schema was not part of the change.

Core trac ticket: https://core.trac.wordpress.org/ticket/61543




## Testing

### Set up

- See [make.wordpress.org/cli/handbook/contributions/pull-requests/#setting-up](https://make.wordpress.org/cli/handbook/contributions/pull-requests/#setting-up)
- Install and prepare dependencies:

```
brew install jq mysql
brew service start mysql
mysql_secure_installation
sudo mysql -u root -p

# MySQL Session
CREATE DATABASE IF NOT EXISTS `wp_cli_test`;
CREATE USER 'wp_cli_test'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password1';
GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost";
\q
```

Before running any of the test (manual or automatic), make sure to set the `THEME_JSON_SOURCE` to ['' (empty string)](https://github.com/wp-cli/i18n-command/blob/main/src/JsonSchemaExtractor.php#L18) so the `ThemeJsonExtractor` picks the the local backup file with the changes at `assets/theme-i18n.json`.

Automated tests:

```
composer install
composer behat -- features/makepot.feature
```

Manual tests:

Create a new directory called `foo-theme` that contains a theme.json file with the following contents:

```json
{
    "description": "My style variation description"
}
```

Run `vendor/bin/wp i18n make-pot foo-theme`

Verify that there's a `foo-theme/foo-theme.pot` file and that the "My style variation description" string is present as well as its context "Style variation description". 

You should see something like:

```
msgctxt "Style variation description"
msgid "My style variation description"
msgstr ""
```