### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "eftec/bladeone": "3.52",
         "gettext/gettext": "^4.8",
         "mck89/peast": "^1.13.11",
-        "wp-cli/wp-cli": "^2.5"
+        "wp-cli/wp-cli": "^2.12"
     },
     "require-dev": {
         "wp-cli/scaffold-command": "^1.2 || ^2",


### PR DESCRIPTION
For improved PHP 8.4 compatibility.