### PR TITLE
update-po: merge `X-Domain` header

### DIFF
--- a/features/updatepo.feature
+++ b/features/updatepo.feature
@@ -388,3 +388,80 @@ Feature: Update existing PO files from a POT file
       Error: Destination file/folder does not exist.
       """
     And the return code should be 1
+
+  Scenario: Empty target PO file
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.pot file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr ""
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/foo-plugin\n"
+      "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+      "Language-Team: LANGUAGE <LL@li.org>\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "POT-Creation-Date: 2018-05-02T22:06:24+00:00\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "X-Domain: foo-plugin\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #. translators: Old Comment.
+      #: foo-plugin.php:10
+      msgid "Some string"
+      msgstr "Some translated string"
+      """
+    And a foo-plugin/foo-plugin-es_ES.po file:
+      """
+      """
+
+    When I run `wp i18n update-po foo-plugin/foo-plugin.pot foo-plugin/foo-plugin-de_DE.po`
+    Then STDOUT should be:
+      """
+      Success: Updated 1 file.
+      """
+    And the foo-plugin/foo-plugin-de_DE.po file should contain:
+      """
+      #. translators: New Comment.
+      #: foo-plugin.php:1
+      msgid "Some string"
+      msgstr "Some translated string"
+
+      #: foo-plugin.php:15
+      msgid "Another new string"
+      msgstr ""
+      """
+    And the foo-plugin/foo-plugin-de_DE.po file should contain:
+    """
+    "X-Domain: foo-plugin\n"
+    """

--- a/src/UpdatePoCommand.php
+++ b/src/UpdatePoCommand.php
@@ -84,7 +84,7 @@ class UpdatePoCommand extends WP_CLI_Command {
 			$po_translations = Translations::fromPoFile( $file->getPathname() );
 			$po_translations->mergeWith(
 				$pot_translations,
-				Merge::ADD | Merge::REMOVE | Merge::COMMENTS_THEIRS | Merge::EXTRACTED_COMMENTS_THEIRS | Merge::REFERENCES_THEIRS
+				Merge::ADD | Merge::REMOVE | Merge::COMMENTS_THEIRS | Merge::EXTRACTED_COMMENTS_THEIRS | Merge::REFERENCES_THEIRS | Merge::DOMAIN_OVERRIDE
 			);
 
 			if ( ! $po_translations->toPoFile( $file->getPathname() ) ) {


### PR DESCRIPTION
Adds the header if missing or overrides existing one

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Fixes #365