### PR TITLE
Fixed inaccurate make-mo command arguments docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ wp i18n make-mo <source> [<destination>]
     $ wp i18n make-mo .
 
     # Create a MO file from a single PO file in a specific directory.
-    $ wp i18n make-mo example-plugin-de_DE.po languages
+    $ wp i18n make-mo languages/example-plugin-de_DE.po
 
     # Create a MO file from a single PO file to a specific file destination
     $ wp i18n make-mo example-plugin-de_DE.po languages/bar.mo
@@ -255,7 +255,7 @@ wp i18n make-php <source> [<destination>]
     Success: Created 3 files.
 
     # Create a PHP file from a single PO file in a specific directory.
-    $ wp i18n make-php example-plugin-de_DE.po languages
+    $ wp i18n make-php languages/example-plugin-de_DE.po
     Success: Created 1 file.
 
 

--- a/src/MakeMoCommand.php
+++ b/src/MakeMoCommand.php
@@ -28,7 +28,7 @@ class MakeMoCommand extends WP_CLI_Command {
 	 *     $ wp i18n make-mo .
 	 *
 	 *     # Create a MO file from a single PO file in a specific directory.
-	 *     $ wp i18n make-mo example-plugin-de_DE.po languages
+	 *     $ wp i18n make-mo languages/example-plugin-de_DE.po
 	 *
 	 *     # Create a MO file from a single PO file to a specific file destination
 	 *     $ wp i18n make-mo example-plugin-de_DE.po languages/bar.mo

--- a/src/MakePhpCommand.php
+++ b/src/MakePhpCommand.php
@@ -29,7 +29,7 @@ class MakePhpCommand extends WP_CLI_Command {
 	 *     Success: Created 3 files.
 	 *
 	 *     # Create a PHP file from a single PO file in a specific directory.
-	 *     $ wp i18n make-php example-plugin-de_DE.po languages
+	 *     $ wp i18n make-php languages/example-plugin-de_DE.po
 	 *     Success: Created 1 file.
 	 *
 	 * @when before_wp_load


### PR DESCRIPTION
Follow-up to
- #372 
- #373 

## Problem
The documentation on https://developer.wordpress.org/cli/commands/i18n/make-mo/ and in the help is inaccurate and misleading.  It states:
> ```
> # Create a MO file from a single PO file in a specific directory.
> $ wp i18n make-mo example-plugin-de_DE.po languages
> ```

But the suggested command yields an error:

```console
$ wp i18n make-mo woocommerce-de_DE.po wp-content/languages/plugins
Error: Source file or directory does not exist.
```

The correct command argument is to just specify the file including path:

```console
$ wp i18n make-mo wp-content/languages/plugins/woocommerce-de_DE.po
Success: Created 1 file.
```

## Proposed solution
Correct the documentation.