### PR TITLE
Add support for custom translation blade directives

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3092,6 +3092,38 @@ Feature: Generate a POT file of a WordPress project
       msgid "Page not found."
       """
 
+@blade
+  Scenario: Extract strings from custom directives from a Blade-PHP file in a theme
+    Given an empty foo-theme directory
+    And a foo-theme/style.css file:
+      """
+      /*
+      Theme Name:     Foo Theme
+      Theme URI:      https://example.com
+      Description:
+      Author:
+      Author URI:
+      Version:        0.1.0
+      License:        GPL-2.0+
+      Text Domain:    foo-theme
+      */
+      """
+    And a foo-theme/stuff.blade.php file:
+      """
+        @t( 'This is a custom directive', 'foo-theme' )
+      """
+
+    When I try `wp i18n make-pot foo-theme --blade-directives=t result.pot --debug`
+    Then STDOUT should be:
+      """
+      Theme stylesheet detected.
+      Success: POT file successfully generated.
+      """
+    And the result.pot file should contain:
+      """
+      msgid "This is a custom directive"
+      """
+
   Scenario: Custom package name
     Given an empty example-project directory
     And a example-project/stuff.php file:

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -3092,7 +3092,7 @@ Feature: Generate a POT file of a WordPress project
       msgid "Page not found."
       """
 
-@blade
+  @blade
   Scenario: Extract strings from custom directives from a Blade-PHP file in a theme
     Given an empty foo-theme directory
     And a foo-theme/style.css file:

--- a/src/BladeCodeExtractor.php
+++ b/src/BladeCodeExtractor.php
@@ -40,6 +40,7 @@ final class BladeCodeExtractor extends BladeGettextExtractor {
 			'__ngettext'      => 'single_plural_number_domain',
 			'__ngettext_noop' => 'single_plural_domain',
 		],
+		'directives'      => [],
 	];
 
 	protected static $functionsScannerClass = 'WP_CLI\I18n\PhpFunctionsScanner';

--- a/src/BladeGettextExtractor.php
+++ b/src/BladeGettextExtractor.php
@@ -21,6 +21,16 @@ class BladeGettextExtractor extends \Gettext\Extractors\PhpCode {
 	protected static function getBladeCompiler() {
 		$cache_path     = empty( $options['cachePath'] ) ? sys_get_temp_dir() : $options['cachePath'];
 		$blade_compiler = new BladeOne( null, $cache_path );
+		$directives     = empty( static::$options['directives'] ) ? [] : static::$options['directives'];
+
+		foreach ( $directives as $directive ) {
+			$blade_compiler->directive(
+				$directive,
+				function ( $expression ) {
+					return "<?php __($expression); ?>";
+				}
+			);
+		}
 
 		if ( method_exists( $blade_compiler, 'withoutComponentTags' ) ) {
 			$blade_compiler->withoutComponentTags();

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -125,6 +125,11 @@ class MakePotCommand extends WP_CLI_Command {
 	protected $project_type = 'generic';
 
 	/**
+	 * @var array
+	 */
+	protected $directives = [];
+
+	/**
 	 * These Regexes copied from http://php.net/manual/en/function.sprintf.php#93552
 	 * and adjusted for better precision and updated specs.
 	 */
@@ -231,6 +236,9 @@ class MakePotCommand extends WP_CLI_Command {
 	 * Defaults to true, use `--no-location` to skip the removal.
 	 * Note that disabling this option makes it harder for technically skilled translators to understand each message’s context.
 	 *
+	 * [--blade-directives=<blade-directives>]
+	 * : Custom Blade directives that should be treated as translation functions. Comma separated list for multiple.
+	 *
 	 * [--skip-js]
 	 * : Skips JavaScript string extraction. Useful when this is done in another build step, e.g. through Babel.
 	 *
@@ -334,6 +342,15 @@ class MakePotCommand extends WP_CLI_Command {
 		$this->file_comment    = Utils\get_flag_value( $assoc_args, 'file-comment' );
 		$this->package_name    = Utils\get_flag_value( $assoc_args, 'package-name' );
 		$this->location        = Utils\get_flag_value( $assoc_args, 'location', true );
+		$this->directives      = array_map(
+			function ( $directive ) {
+				return trim( ltrim( $directive, '@' ) );
+			},
+			explode(
+				',',
+				Utils\get_flag_value( $assoc_args, 'blade-directives', '' )
+			)
+		);
 
 		$ignore_domain = Utils\get_flag_value( $assoc_args, 'ignore-domain', false );
 
@@ -659,6 +676,8 @@ class MakePotCommand extends WP_CLI_Command {
 					'extensions'    => [ 'blade.php' ],
 					'addReferences' => $this->location,
 				];
+
+				BladeCodeExtractor::$options['directives'] += $this->directives;
 				BladeCodeExtractor::fromDirectory( $this->source, $translations, $options );
 			}
 


### PR DESCRIPTION
Solves #435 

Add a new option `--blade-directives` making it possible to use custom directives as translation functions.
These directives will be rewritten to `__(` to allow them to be picked up as translation strings.
