### PR TITLE
Tests: avoid `setAccessible` deprecation warnings

### DIFF
--- a/tests/IterableCodeExtractorTest.php
+++ b/tests/IterableCodeExtractorTest.php
@@ -22,9 +22,13 @@ class IterableCodeExtractorTest extends TestCase {
 		self::$base = Utils\normalize_path( __DIR__ ) . '/data/';
 
 		$property = new \ReflectionProperty( TestIterableCodeExtractor::class, 'dir' );
-		$property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( null, self::$base );
-		$property->setAccessible( false );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( false );
+		}
 	}
 
 	public function tear_down() {
@@ -211,7 +215,9 @@ class IterableCodeExtractorTest extends TestCase {
 	protected static function get_method_as_public( $class_name, $method_name ) {
 		$class  = new \ReflectionClass( $class_name );
 		$method = $class->getMethod( $method_name );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		return $method;
 	}
 

--- a/tests/MakeJsonMapTest.php
+++ b/tests/MakeJsonMapTest.php
@@ -27,7 +27,9 @@ class MakeJsonMapTest extends TestCase {
 		self::$obj       = new MakeJsonCommand();
 		$reflection      = new \ReflectionClass( get_class( self::$obj ) );
 		self::$build_map = $reflection->getMethod( 'build_map' );
-		self::$build_map->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			self::$build_map->setAccessible( true );
+		}
 	}
 
 	public function test_no_map() {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/6110