### PR TITLE
Normalize text domain string in make-json command

### DIFF
--- a/features/makejson.feature
+++ b/features/makejson.feature
@@ -1089,3 +1089,43 @@ Feature: Split PO files into JSON files.
       """
       "source":"app.min.admin.js"
       """
+
+  Scenario: Normalizes domain in X-Domain header and --domain argument
+    Given an empty foo-plugin directory
+    And a foo-plugin/de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "X-Domain: ../../../invalid-domain\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: script.js:5
+      msgid "Script"
+      msgstr "Skript"
+      """
+
+    When I run `wp i18n make-json foo-plugin`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/invalid-domain-de_DE-9a9569e9d73f33740eada95275da7f30.json file should exist
+    And the invalid-domain-de_DE-9a9569e9d73f33740eada95275da7f30.json file should not exist
+
+    When I run `wp i18n make-json foo-plugin --domain=../../another-invalid`
+    Then STDOUT should contain:
+      """
+      Success: Created 1 file.
+      """
+    And the return code should be 0
+    And the foo-plugin/another-invalid-de_DE-9a9569e9d73f33740eada95275da7f30.json file should exist
+    And the another-invalid-de_DE-9a9569e9d73f33740eada95275da7f30.json file should not exist
+
+

--- a/src/MakeJsonCommand.php
+++ b/src/MakeJsonCommand.php
@@ -249,6 +249,10 @@ class MakeJsonCommand extends WP_CLI_Command {
 
 		$domain = ( ! empty( $domain ) ) ? $domain : $translations->getDomain();
 
+		if ( ! empty( $domain ) ) {
+			$domain = preg_replace( '/[^a-z0-9-]/i', '', $domain );
+		}
+
 		if ( $domain && 0 !== strpos( $base_file_name, $domain ) ) {
 			$base_file_name = "{$domain}-{$base_file_name}";
 		}


### PR DESCRIPTION
Applying some slight hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when generating JSON filenames from translation domains.
  * Domain values from headers and command-line options are now normalized to safe filenames, preventing directory traversal issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->