### PR TITLE
Reject invalid Domain Paths in make-pot

### DIFF
--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -326,6 +326,25 @@ Feature: Generate a POT file of a WordPress project
     And STDERR should be empty
     And the foo-plugin/languages/foo-plugin.pot file should exist
 
+  Scenario: Refuses Domain Path header with invalid path.
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Foo Plugin
+       * Text Domain: foo-plugin
+       * Domain Path: ../../../../../../../../tmp/custom-languages
+       */
+      """
+
+    When I try `wp i18n make-pot foo-plugin`
+    Then STDERR should contain:
+      """
+      Error: Invalid Domain Path value: ../../../../../../../../tmp/custom-languages
+      """
+    And the return code should be 1
+
   Scenario: Uses Text Domain header when no domain is set.
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin.php file:

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -393,13 +393,21 @@ class MakePotCommand extends WP_CLI_Command {
 		if ( isset( $this->main_file_data['Domain Path'] ) && is_array( $this->main_file_data['Domain Path'] ) ) {
 			$domain_path_val = $this->main_file_data['Domain Path']['value'] ?? '';
 			if ( is_scalar( $domain_path_val ) && ! empty( $domain_path_val ) ) {
-				// Domain Path inside source folder.
-				$this->destination = sprintf(
-					'%s/%s/%s.pot',
-					$this->source,
-					$this->unslashit( (string) $domain_path_val ),
-					$this->slug
-				);
+				$domain_path = $this->unslashit( Path::normalize( (string) $domain_path_val ) );
+
+				if ( false !== strpos( $domain_path, '..' ) || Path::is_absolute( $domain_path ) || Path::is_stream( $domain_path ) ) {
+					WP_CLI::error( sprintf( 'Invalid Domain Path value: %s', $domain_path_val ) );
+				}
+
+				if ( ! empty( $domain_path ) ) {
+					// Domain Path inside source folder.
+					$this->destination = sprintf(
+						'%s/%s/%s.pot',
+						$this->source,
+						$domain_path,
+						$this->slug
+					);
+				}
 			}
 		}
 

--- a/src/MakePotCommand.php
+++ b/src/MakePotCommand.php
@@ -395,7 +395,7 @@ class MakePotCommand extends WP_CLI_Command {
 			if ( is_scalar( $domain_path_val ) && ! empty( $domain_path_val ) ) {
 				$domain_path = $this->unslashit( Path::normalize( (string) $domain_path_val ) );
 
-				if ( false !== strpos( $domain_path, '..' ) || Path::is_absolute( $domain_path ) || Path::is_stream( $domain_path ) ) {
+				if ( preg_match( '#(?:^|/)\.\.(?:/|$)#', $domain_path ) || Path::is_absolute( $domain_path ) || Path::is_stream( $domain_path ) ) {
 					WP_CLI::error( sprintf( 'Invalid Domain Path value: %s', $domain_path_val ) );
 				}
 


### PR DESCRIPTION
Applying some slight hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of plugin translation `Domain Path` values.
  * Rejects absolute paths, stream paths, and parent-directory traversal values.
  * Valid paths continue to generate POT files in the expected source directory.
  * Invalid values are reported on STDERR, and the command exits with status 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->