### PR TITLE
Write the revision date as translation-revision-date in make-php

### DIFF
--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -153,10 +153,10 @@ Feature: Generate PHP files from PO files
     And STDERR should be empty
     And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
-      return ['domain'=>NULL,'plural-forms'=>'nplurals=2; plural=n != 1;','language'=>'de_DE','project-id-version'=>'Development (5.2.x)','pot-creation-date'=>'','translation-revision-date'=>'2019-03-28 19:42+0300','po-revision-date'=>'2019-03-28 19:42+0300','x-generator'=>'Poedit 2.2.1','messages'=>['html_lang_attribute'=>'de-DE','text directionltr'=>'ltr','number_format_decimal_point'=>',','number_format_thousands_sep'=>'.','Update %s now'=>'Jetzt %s aktualisieren','[%1$s] Confirm Action: %2$s'=>'[%1$s] Aktion bestätigen: %2$s','[%s] Erasure Request Fulfilled'=>'[%s] Löschauftrag ausgeführt','[%s] Personal Data Export'=>'[%s] Export personenbezogener Daten']];
+      return ['domain'=>NULL,'plural-forms'=>'nplurals=2; plural=n != 1;','language'=>'de_DE','project-id-version'=>'Development (5.2.x)','pot-creation-date'=>'','translation-revision-date'=>'2019-03-28 19:42+0300','x-generator'=>'Poedit 2.2.1','messages'=>['html_lang_attribute'=>'de-DE','text directionltr'=>'ltr','number_format_decimal_point'=>',','number_format_thousands_sep'=>'.','Update %s now'=>'Jetzt %s aktualisieren','[%1$s] Confirm Action: %2$s'=>'[%1$s] Aktion bestätigen: %2$s','[%s] Erasure Request Fulfilled'=>'[%s] Löschauftrag ausgeführt','[%s] Personal Data Export'=>'[%s] Export personenbezogener Daten']];
       """
 
-  Scenario: Writes the revision date under both header keys
+  Scenario: Writes the revision date as translation-revision-date
     Given an empty foo-plugin directory
     And a foo-plugin/foo-plugin-de_DE.po file:
       """
@@ -183,9 +183,9 @@ Feature: Generate PHP files from PO files
       """
       'translation-revision-date'=>'2018-05-02T22:06:24+00:00'
       """
-    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should not contain:
       """
-      'po-revision-date'=>'2018-05-02T22:06:24+00:00'
+      'po-revision-date'
       """
 
   Scenario: Does include translations

--- a/features/makephp.feature
+++ b/features/makephp.feature
@@ -153,7 +153,39 @@ Feature: Generate PHP files from PO files
     And STDERR should be empty
     And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
       """
-      return ['domain'=>NULL,'plural-forms'=>'nplurals=2; plural=n != 1;','language'=>'de_DE','project-id-version'=>'Development (5.2.x)','pot-creation-date'=>'','po-revision-date'=>'2019-03-28 19:42+0300','x-generator'=>'Poedit 2.2.1','messages'=>['html_lang_attribute'=>'de-DE','text directionltr'=>'ltr','number_format_decimal_point'=>',','number_format_thousands_sep'=>'.','Update %s now'=>'Jetzt %s aktualisieren','[%1$s] Confirm Action: %2$s'=>'[%1$s] Aktion bestätigen: %2$s','[%s] Erasure Request Fulfilled'=>'[%s] Löschauftrag ausgeführt','[%s] Personal Data Export'=>'[%s] Export personenbezogener Daten']];
+      return ['domain'=>NULL,'plural-forms'=>'nplurals=2; plural=n != 1;','language'=>'de_DE','project-id-version'=>'Development (5.2.x)','pot-creation-date'=>'','translation-revision-date'=>'2019-03-28 19:42+0300','po-revision-date'=>'2019-03-28 19:42+0300','x-generator'=>'Poedit 2.2.1','messages'=>['html_lang_attribute'=>'de-DE','text directionltr'=>'ltr','number_format_decimal_point'=>',','number_format_thousands_sep'=>'.','Update %s now'=>'Jetzt %s aktualisieren','[%1$s] Confirm Action: %2$s'=>'[%1$s] Aktion bestätigen: %2$s','[%s] Erasure Request Fulfilled'=>'[%s] Löschauftrag ausgeführt','[%s] Personal Data Export'=>'[%s] Export personenbezogener Daten']];
+      """
+
+  Scenario: Writes the revision date under both header keys
+    Given an empty foo-plugin directory
+    And a foo-plugin/foo-plugin-de_DE.po file:
+      """
+      # Copyright (C) 2018 Foo Plugin
+      # This file is distributed under the same license as the Foo Plugin package.
+      msgid ""
+      msgstr ""
+      "Project-Id-Version: Foo Plugin\n"
+      "Language: de_DE\n"
+      "MIME-Version: 1.0\n"
+      "Content-Type: text/plain; charset=UTF-8\n"
+      "Content-Transfer-Encoding: 8bit\n"
+      "PO-Revision-Date: 2018-05-02T22:06:24+00:00\n"
+      "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+      #: foo-plugin.php:15
+      msgid "Foo Plugin"
+      msgstr "Bar Plugin"
+      """
+
+    When I run `wp i18n make-php foo-plugin`
+    Then the return code should be 0
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
+      """
+      'translation-revision-date'=>'2018-05-02T22:06:24+00:00'
+      """
+    And the foo-plugin/foo-plugin-de_DE.l10n.php file should contain:
+      """
+      'po-revision-date'=>'2018-05-02T22:06:24+00:00'
       """
 
   Scenario: Does include translations

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -72,24 +72,17 @@ class PhpArrayGenerator extends PhpArray {
 			$result['language'] = $language;
 		}
 
-		/*
-		 * `PO-Revision-Date` maps onto two keys. GlotPress exports the revision date as
-		 * `translation-revision-date`, which is what the language packs on WordPress.org
-		 * ship and what `make-json` already emits, while WordPress reads `po-revision-date`
-		 * in `wp_get_l10n_php_file_data()`. Writing both keeps the file readable either way.
-		 */
+		// GlotPress exports the revision date as `translation-revision-date`, so use that name here too.
 		$headers_allowlist = [
-			'POT-Creation-Date'  => [ 'pot-creation-date' ],
-			'PO-Revision-Date'   => [ 'translation-revision-date', 'po-revision-date' ],
-			'Project-Id-Version' => [ 'project-id-version' ],
-			'X-Generator'        => [ 'x-generator' ],
+			'POT-Creation-Date'  => 'pot-creation-date',
+			'PO-Revision-Date'   => 'translation-revision-date',
+			'Project-Id-Version' => 'project-id-version',
+			'X-Generator'        => 'x-generator',
 		];
 
 		foreach ( $translations->getHeaders() as $name => $value ) {
 			if ( isset( $headers_allowlist[ $name ] ) ) {
-				foreach ( $headers_allowlist[ $name ] as $key ) {
-					$result[ $key ] = $value;
-				}
+				$result[ $headers_allowlist[ $name ] ] = $value;
 			}
 		}
 

--- a/src/PhpArrayGenerator.php
+++ b/src/PhpArrayGenerator.php
@@ -72,16 +72,24 @@ class PhpArrayGenerator extends PhpArray {
 			$result['language'] = $language;
 		}
 
+		/*
+		 * `PO-Revision-Date` maps onto two keys. GlotPress exports the revision date as
+		 * `translation-revision-date`, which is what the language packs on WordPress.org
+		 * ship and what `make-json` already emits, while WordPress reads `po-revision-date`
+		 * in `wp_get_l10n_php_file_data()`. Writing both keeps the file readable either way.
+		 */
 		$headers_allowlist = [
-			'POT-Creation-Date'  => 'pot-creation-date',
-			'PO-Revision-Date'   => 'po-revision-date',
-			'Project-Id-Version' => 'project-id-version',
-			'X-Generator'        => 'x-generator',
+			'POT-Creation-Date'  => [ 'pot-creation-date' ],
+			'PO-Revision-Date'   => [ 'translation-revision-date', 'po-revision-date' ],
+			'Project-Id-Version' => [ 'project-id-version' ],
+			'X-Generator'        => [ 'x-generator' ],
 		];
 
 		foreach ( $translations->getHeaders() as $name => $value ) {
 			if ( isset( $headers_allowlist[ $name ] ) ) {
-				$result[ $headers_allowlist[ $name ] ] = $value;
+				foreach ( $headers_allowlist[ $name ] as $key ) {
+					$result[ $key ] = $value;
+				}
 			}
 		}
 


### PR DESCRIPTION
## The problem

`make-php` writes the revision date of a generated `.l10n.php` file as `po-revision-date` (`src/PhpArrayGenerator.php`).

GlotPress — the reference producer of these files, and the one behind every language pack on WordPress.org — writes `translation-revision-date`, and writes no `po-revision-date` at all:

```php
// GlotPress, gp-includes/formats/format-php.php
$result = array(
    'x-generator'               => 'GlotPress/' . GP_VERSION,
    'translation-revision-date' => GP::$translation->last_modified( $translation_set ) . '+0000',
    ...
);
```

`JedGenerator` in this package already uses `translation-revision-date` for the same value in the JSON output (`src/JedGenerator.php`), so `make-php` was the odd one out for a class whose docblock says it "returns output in the form WordPress uses".

## The change

`make-php` now emits `translation-revision-date` instead of `po-revision-date`, matching GlotPress exactly.

## What this means for `wp_get_l10n_php_file_data()`

Worth being explicit about, since this renames a key that something reads.

WordPress reads `po-revision-date` in `wp_get_l10n_php_file_data()`, added in 6.6 and unchanged since, and that value feeds `wp_get_installed_translations()`. After this change, the revision date core reports for a `make-php`-generated file is empty on currently released WordPress versions.

That is already the situation for every language pack shipped from WordPress.org, because GlotPress never writes `po-revision-date` — `wp_get_l10n_php_file_data()` returns an empty revision date for those files today. So this aligns `make-php` output with the files core already receives in practice, rather than opening a new gap.

Core is separately looking at reading `translation-revision-date` in that function (Trac [#65809](https://core.trac.wordpress.org/ticket/65809)).

The alternative would be to write both keys, which keeps the value readable on current WordPress versions at the cost of no longer matching the reference format byte for byte. This PR deliberately takes the matching-GlotPress route.

## Testing

`features/makephp.feature` gains a scenario asserting that a PO with `PO-Revision-Date` produces `translation-revision-date` and no `po-revision-date`. The existing "Does include headers" scenario, which asserts the full generated array, is updated for the renamed key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated PHP metadata so `PO-Revision-Date` is recorded as `translation-revision-date`.
  * Removed the duplicate `po-revision-date` field from generated metadata.
  * Improved header processing to preserve supported metadata while generating PHP arrays.
  * Added coverage to verify the updated metadata output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->