### PR TITLE
Fix PHPCS errors in Behat test files

### DIFF
--- a/features/audit.feature
+++ b/features/audit.feature
@@ -107,7 +107,7 @@ Feature: Audit strings in a WordPress project
        * Text Domain: foo-plugin
        */
 
-      __( 'Hello %s %s', 'foo-plugin' );
+      __( 'Hello %1$s %2$s', 'foo-plugin' );
       """
 
     When I try `wp i18n audit foo-plugin`

--- a/features/audit.feature
+++ b/features/audit.feature
@@ -107,7 +107,7 @@ Feature: Audit strings in a WordPress project
        * Text Domain: foo-plugin
        */
 
-      __( 'Hello %1$s %2$s', 'foo-plugin' );
+      __( 'Hello %s %s', 'foo-plugin' ); // phpcs:ignore WordPress.WP.I18n.UnorderedPlaceholdersText -- Unordered on purpose, this is what the audit is expected to flag.
       """
 
     When I try `wp i18n audit foo-plugin`

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -893,8 +893,8 @@ Feature: Generate a POT file of a WordPress project
        */
 
       sprintf(
-        _n( 'One Comment', '%s Comments', $number, 'foo-plugin' ),
-        $number
+          _n( 'One Comment', '%s Comments', $number, 'foo-plugin' ),
+          $number
       );
 
       """
@@ -920,9 +920,9 @@ Feature: Generate a POT file of a WordPress project
        */
 
       sprintf(
-        _n( '%1$s Comment (%2$d)', '%2$s Comments (%1$s)', $number, 'foo-plugin' ),
-        $number,
-        $another_variable
+          _n( '%1$s Comment (%2$d)', '%2$s Comments (%1$s)', $number, 'foo-plugin' ),
+          $number,
+          $another_variable
       );
 
       """
@@ -948,9 +948,9 @@ Feature: Generate a POT file of a WordPress project
        */
 
       sprintf(
-        __( 'Hello %s %s', 'foo-plugin' ),
-        $a_variable,
-        $another_variable
+          __( 'Hello %1$s %2$s', 'foo-plugin' ),
+          $a_variable,
+          $another_variable
       );
 
       """

--- a/features/makepot.feature
+++ b/features/makepot.feature
@@ -948,7 +948,7 @@ Feature: Generate a POT file of a WordPress project
        */
 
       sprintf(
-          __( 'Hello %1$s %2$s', 'foo-plugin' ),
+          __( 'Hello %s %s', 'foo-plugin' ), // phpcs:ignore WordPress.WP.I18n.UnorderedPlaceholdersText -- Unordered on purpose, this is what make-pot is expected to warn about.
           $a_variable,
           $another_variable
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated audit scenarios to preserve intentionally unordered placeholders when validating placeholder-order warnings.
  * Added an exception annotation so the audit’s own code-quality checks do not flag the intentional test fixture.
  * Improved formatting of related translation test cases without changing expected assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->